### PR TITLE
Fix deploy workflow path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: './dist'
+          path: 'dist'
 
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
Change path from './dist' to 'dist' to fix artifact upload issue causing source files to be included in deployment.