### PR TITLE
Add cache-busting query params

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <meta name="description" content="A 3D endless runner game where you dodge poop obstacles as a toilet paper roll!">
   <title>Toilet Runner</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="stylesheet" href="styles/modals.css">
+  <link rel="stylesheet" href="styles/modals.css?v=2">
   <link href="https://fonts.googleapis.com/css2?family=Fredoka+One&display=swap" rel="stylesheet">
 </head>
 <body>
@@ -81,6 +81,6 @@
     </div>
   </div>
   
-  <script type="module" src="./src/main.ts"></script>
+  <script type="module" src="./src/main.ts?v=2"></script>
 </body>
 </html>


### PR DESCRIPTION
Add ?v=2 query params to stylesheet and script references to force GitHub Pages cache invalidation.