### PR TITLE
feat: gameplay polish — animations, lane lines, UI improvements

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,12 +4,12 @@
     "": {
       "name": "toilet-runner",
       "dependencies": {
-        "playwright": "^1.57.0",
         "three": "^0.170.0",
       },
       "devDependencies": {
         "@types/three": "^0.170.0",
         "gh-pages": "^6.2.0",
+        "playwright": "^1.57.0",
         "vite": "^6.0.0",
       },
     },
@@ -173,7 +173,7 @@
 
     "fs-extra": ["fs-extra@11.3.3", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg=="],
 
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "gh-pages": ["gh-pages@6.3.0", "", { "dependencies": { "async": "^3.2.4", "commander": "^13.0.0", "email-addresses": "^5.0.0", "filenamify": "^4.3.0", "find-cache-dir": "^3.3.1", "fs-extra": "^11.1.1", "globby": "^11.1.0" }, "bin": { "gh-pages": "bin/gh-pages.js", "gh-pages-clean": "bin/gh-pages-clean.js" } }, "sha512-Ot5lU6jK0Eb+sszG8pciXdjMXdBJ5wODvgjR+imihTqsUWF2K6dJ9HST55lgqcs8wWcw6o6wAsUzfcYRhJPXbA=="],
 
@@ -257,6 +257,8 @@
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
-    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+    "rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
   }
 }

--- a/src/game/visual/SpeedLines.ts
+++ b/src/game/visual/SpeedLines.ts
@@ -1,0 +1,92 @@
+import * as THREE from 'three';
+
+const LINE_COUNT = 20;
+const SPEED_THRESHOLD = 15;
+const LINE_Z_RANGE = 40; // Spread lines from -40 to 0 (in front of player)
+const LINE_RESET_Z = 10; // Reset when line passes behind player
+
+export class SpeedLines {
+  private _mesh: THREE.InstancedMesh;
+  private _positions: Float32Array;
+  private _tempMatrix: THREE.Matrix4;
+  private _material: THREE.MeshBasicMaterial;
+
+  constructor(scene: THREE.Scene) {
+    this._tempMatrix = new THREE.Matrix4();
+
+    const geometry = new THREE.PlaneGeometry(0.04, 3);
+    this._material = new THREE.MeshBasicMaterial({
+      color: 0xffffff,
+      transparent: true,
+      opacity: 0,
+      depthWrite: false,
+      side: THREE.DoubleSide,
+    });
+
+    this._mesh = new THREE.InstancedMesh(geometry, this._material, LINE_COUNT);
+    this._mesh.frustumCulled = false;
+    scene.add(this._mesh);
+
+    // Initialize random positions
+    this._positions = new Float32Array(LINE_COUNT * 3);
+    for (let i = 0; i < LINE_COUNT; i++) {
+      this._positions[i * 3] = (Math.random() - 0.5) * 12;     // x: spread across lanes
+      this._positions[i * 3 + 1] = Math.random() * 4 + 0.5;    // y: above ground
+      this._positions[i * 3 + 2] = -Math.random() * LINE_Z_RANGE; // z: in front
+      this._updateInstance(i);
+    }
+    this._mesh.instanceMatrix.needsUpdate = true;
+  }
+
+  private _updateInstance(i: number): void {
+    const x = this._positions[i * 3];
+    const y = this._positions[i * 3 + 1];
+    const z = this._positions[i * 3 + 2];
+    // Rotate plane to lie along Z-axis (horizontal streak)
+    this._tempMatrix.makeRotationX(Math.PI / 2);
+    this._tempMatrix.setPosition(x, y, z);
+    this._mesh.setMatrixAt(i, this._tempMatrix);
+  }
+
+  update(delta: number, gameSpeed: number): void {
+    if (gameSpeed <= SPEED_THRESHOLD) {
+      this._material.opacity = 0;
+      return;
+    }
+
+    // Intensity scales from 0 to 1 as speed goes from threshold to threshold+10
+    const intensity = Math.min((gameSpeed - SPEED_THRESHOLD) / 10, 1);
+    this._material.opacity = intensity * 0.35;
+
+    const moveDelta = gameSpeed * delta * 1.5;
+
+    for (let i = 0; i < LINE_COUNT; i++) {
+      this._positions[i * 3 + 2] += moveDelta;
+
+      // Reset line when it passes behind
+      if (this._positions[i * 3 + 2] > LINE_RESET_Z) {
+        this._positions[i * 3] = (Math.random() - 0.5) * 12;
+        this._positions[i * 3 + 1] = Math.random() * 4 + 0.5;
+        this._positions[i * 3 + 2] = -LINE_Z_RANGE + Math.random() * 5;
+      }
+      this._updateInstance(i);
+    }
+    this._mesh.instanceMatrix.needsUpdate = true;
+  }
+
+  reset(): void {
+    this._material.opacity = 0;
+    for (let i = 0; i < LINE_COUNT; i++) {
+      this._positions[i * 3] = (Math.random() - 0.5) * 12;
+      this._positions[i * 3 + 1] = Math.random() * 4 + 0.5;
+      this._positions[i * 3 + 2] = -Math.random() * LINE_Z_RANGE;
+      this._updateInstance(i);
+    }
+    this._mesh.instanceMatrix.needsUpdate = true;
+  }
+
+  dispose(): void {
+    this._mesh.geometry.dispose();
+    this._material.dispose();
+  }
+}

--- a/styles/modals.css
+++ b/styles/modals.css
@@ -728,13 +728,29 @@
 
 .game-over-message.new-best {
   color: var(--accent);
-  text-shadow: 0 0 8px rgba(255, 215, 0, 0.4);
-  animation: pulse-glow 1.5s ease-in-out infinite;
+  text-shadow: 0 0 12px rgba(255, 215, 0, 0.6);
+  animation: newBestEntry 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) forwards, pulse-glow 1.5s ease-in-out 0.5s infinite;
+}
+
+@keyframes newBestEntry {
+  0% { transform: scale(0); opacity: 0; }
+  60% { transform: scale(1.2); opacity: 1; }
+  100% { transform: scale(1); opacity: 1; }
 }
 
 @keyframes pulse-glow {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.7; }
+  0%, 100% { opacity: 1; text-shadow: 0 0 12px rgba(255, 215, 0, 0.6); }
+  50% { opacity: 0.8; text-shadow: 0 0 20px rgba(255, 215, 0, 0.8); }
+}
+
+#final-score.score-counted {
+  animation: scoreBounce 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+@keyframes scoreBounce {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.15); }
+  100% { transform: scale(1); }
 }
 
 /* Near miss toast */
@@ -1586,6 +1602,39 @@ button:focus-visible {
 #challenges-list::-webkit-scrollbar-thumb:hover,
 .stats-grid::-webkit-scrollbar-thumb:hover {
   background: var(--primary-dark);
+}
+
+/* Score Popup on dodge */
+.score-popup {
+  position: fixed;
+  top: 30%;
+  left: 50%;
+  transform: translateX(-50%);
+  font-family: 'Fredoka One', cursive, var(--font-family);
+  font-size: 24px;
+  font-weight: 800;
+  color: white;
+  text-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
+  pointer-events: none;
+  z-index: 5000;
+  animation: scorePopupRise 0.8s ease-out forwards;
+}
+
+.score-popup.near-miss {
+  font-size: 30px;
+  color: var(--accent);
+  text-shadow: 0 0 12px rgba(255, 215, 0, 0.6), 0 2px 6px rgba(0, 0, 0, 0.5);
+}
+
+@keyframes scorePopupRise {
+  0% {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
+  100% {
+    opacity: 0;
+    transform: translateX(-50%) translateY(-60px);
+  }
 }
 
 /* Streak Notification */


### PR DESCRIPTION
## Summary
- **Character animations**: lane-change tilt/squash-stretch, death tumble with slow-mo and screen flash
- **Lane line markings**: white dashed lane dividers rendered via InstancedMesh with proper pooling
- **Speed lines**: new visual effect that scales with game speed
- **UI improvements**: animated score count-up on game over, floating "+10" / "CLOSE!" score popups, spacebar to restart, smoother modal transitions
- **CSS polish**: score popup rise-and-fade animation, score bounce on count-up completion, enhanced "new best" entry animation

## Test plan
- [ ] Play game and verify lane-change tilt animation looks natural
- [ ] Verify lane line markings render between lanes and move with track
- [ ] Collide with obstacle — confirm death tumble, slow-mo, and white flash
- [ ] On game over screen, verify score counts up with ease-out animation
- [ ] Press spacebar on game over screen to restart
- [ ] Dodge obstacles in same lane — verify "+10" popup appears
- [ ] Dodge obstacles in adjacent lane — verify "CLOSE!" popup appears
- [ ] Obstacles in far lanes should pass silently (no popup)
- [ ] Speed lines should be visible and scale with speed

🤖 Generated with [Claude Code](https://claude.com/claude-code)