### PR TITLE
chore: bump version to 1.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toilet-runner",
-  "version": "1.9.0",
+  "version": "1.11.0",
   "description": "3D endless runner with toilet paper roll avoiding poop obstacles",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Version bump for the v1.11.0 release (P0 UX/accessibility fixes + unit test suite from #109).

Production verified on https://bigknoxy.github.io/toilet-runner/ with headed browser: clean console, run plays, held-key repeat does not strobe pause, game-over verdict reports "New Personal Best!" correctly on a fresh profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)