### PR TITLE
fix: Mobile swipe responsiveness

### DIFF
--- a/src/input/InputManager.ts
+++ b/src/input/InputManager.ts
@@ -1,5 +1,8 @@
-const SWIPE_THRESHOLD = 80;
-const SWIPE_VERTICAL_THRESHOLD = 60;
+// Industry norm for a mobile swipe gesture is ~25-35px before it reads as a
+// deliberate directional move (iOS/Android system gestures resolve in that
+// band too). 30px is responsive without tripping on a shaky tap.
+const SWIPE_THRESHOLD = 30;
+const SWIPE_VERTICAL_THRESHOLD = 25;
 const SWIPE_DEBOUNCE_MS = 16;
 const TAP_ZONE_RATIO = 0.3;
 
@@ -8,6 +11,9 @@ export class InputManager {
   private _touchStartY: number = 0;
   private _touchStartTime: number = 0;
   private _lastSwipeTime: number = 0;
+  /** True once the in-progress touch has already fired a lane change/jump via
+   * touchmove, so touchend does not resolve the same gesture a second time. */
+  private _touchGestureConsumed: boolean = false;
   private _onLaneChange: (direction: -1 | 1) => void;
   private _onJump: () => void;
   private _onPause?: () => void;
@@ -52,11 +58,13 @@ export class InputManager {
 
   private setupTouch(): void {
     window.addEventListener('touchstart', this.handleTouchStart, { passive: true, capture: true });
+    window.addEventListener('touchmove', this.handleTouchMove, { passive: true, capture: true });
     window.addEventListener('touchend', this.handleTouchEnd, { passive: true, capture: true });
   }
 
   private removeTouch(): void {
     window.removeEventListener('touchstart', this.handleTouchStart);
+    window.removeEventListener('touchmove', this.handleTouchMove);
     window.removeEventListener('touchend', this.handleTouchEnd);
   }
 
@@ -114,12 +122,51 @@ export class InputManager {
       this._touchStartX = event.touches[0].clientX;
       this._touchStartY = event.touches[0].clientY;
       this._touchStartTime = performance.now();
+      this._touchGestureConsumed = false;
+    }
+  };
+
+  /** Resolves the gesture as soon as a threshold is crossed, so a deliberate
+   * swipe fires immediately instead of waiting for the finger to lift. */
+  private handleTouchMove = (event: TouchEvent): void => {
+    if (!this._acceptsGameplayInput()) return;
+    if (this._touchGestureConsumed) return;
+    if (event.touches.length === 0) return;
+
+    const now = performance.now();
+    if (now - this._lastSwipeTime < SWIPE_DEBOUNCE_MS) return;
+
+    const touchX = event.touches[0].clientX;
+    const touchY = event.touches[0].clientY;
+
+    const deltaX = touchX - this._touchStartX;
+    const deltaY = touchY - this._touchStartY;
+
+    if (deltaY < -SWIPE_VERTICAL_THRESHOLD && Math.abs(deltaX) < SWIPE_THRESHOLD) {
+      this._lastSwipeTime = now;
+      this._touchGestureConsumed = true;
+      this._onJump();
+      return;
+    }
+
+    if (Math.abs(deltaX) > SWIPE_THRESHOLD && Math.abs(deltaY) < SWIPE_THRESHOLD * 1.5) {
+      this._lastSwipeTime = now;
+      this._touchGestureConsumed = true;
+      if (deltaX > 0) {
+        this._onLaneChange(1);
+      } else {
+        this._onLaneChange(-1);
+      }
     }
   };
 
   private handleTouchEnd = (event: TouchEvent): void => {
     if (!this._acceptsGameplayInput()) return;
     if (event.changedTouches.length === 0) return;
+    if (this._touchGestureConsumed) {
+      this._touchGestureConsumed = false;
+      return;
+    }
 
     const now = performance.now();
 

--- a/tests/InputManager.test.ts
+++ b/tests/InputManager.test.ts
@@ -27,6 +27,28 @@ function press(key: string, init: KeyboardEventInit = {}): KeyboardEvent {
   return event;
 }
 
+function touchPoint(x: number, y: number): Touch {
+  return { clientX: x, clientY: y } as unknown as Touch;
+}
+
+function touchStart(x: number, y: number): void {
+  window.dispatchEvent(
+    new TouchEvent('touchstart', { touches: [touchPoint(x, y)] } as unknown as TouchEventInit)
+  );
+}
+
+function touchMove(x: number, y: number): void {
+  window.dispatchEvent(
+    new TouchEvent('touchmove', { touches: [touchPoint(x, y)] } as unknown as TouchEventInit)
+  );
+}
+
+function touchEnd(x: number, y: number): void {
+  window.dispatchEvent(
+    new TouchEvent('touchend', { changedTouches: [touchPoint(x, y)] } as unknown as TouchEventInit)
+  );
+}
+
 beforeEach(() => {
   calls = { lanes: [], jumps: 0, pauses: 0 };
   document.body.innerHTML = '';
@@ -105,5 +127,62 @@ describe('keyboard', () => {
     input.teardown();
     press('ArrowLeft');
     expect(calls.lanes).toEqual([]);
+  });
+});
+
+describe('touch', () => {
+  test('a swipe past the threshold fires during touchmove, before touchend', () => {
+    input = makeInput();
+    touchStart(100, 100);
+    touchMove(140, 100);
+    // The gesture must resolve here, not wait for the finger to lift.
+    expect(calls.lanes).toEqual([1]);
+    touchEnd(140, 100);
+    expect(calls.lanes).toEqual([1]);
+  });
+
+  test('a resolved touchmove gesture does not double-fire on touchend', () => {
+    input = makeInput();
+    touchStart(100, 100);
+    touchMove(60, 100);
+    expect(calls.lanes).toEqual([-1]);
+    touchEnd(60, 100);
+    expect(calls.lanes).toEqual([-1]);
+  });
+
+  test('an upward swipe past the vertical threshold jumps on touchmove', () => {
+    input = makeInput();
+    touchStart(100, 100);
+    touchMove(100, 60);
+    expect(calls.jumps).toBe(1);
+    touchEnd(100, 60);
+    expect(calls.jumps).toBe(1);
+  });
+
+  test('teardown removes the touchmove listener', () => {
+    input = makeInput();
+    input.teardown();
+    touchStart(100, 100);
+    touchMove(140, 100);
+    expect(calls.lanes).toEqual([]);
+  });
+
+  test('gate blocks touchmove swipes', () => {
+    input = makeInput(() => false);
+    touchStart(100, 100);
+    touchMove(140, 100);
+    expect(calls.lanes).toEqual([]);
+    touchEnd(140, 100);
+    expect(calls.lanes).toEqual([]);
+  });
+
+  test('tap-zone fallback still fires on touchend for a short, stationary tap', () => {
+    input = makeInput();
+    const originalWidth = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', { value: 400, configurable: true });
+    touchStart(20, 100);
+    touchEnd(20, 100);
+    expect(calls.lanes).toEqual([-1]);
+    Object.defineProperty(window, 'innerWidth', { value: originalWidth, configurable: true });
   });
 });


### PR DESCRIPTION
## Problem

Swipes only resolved on `touchend` and required 80px of travel. A deliberate lane change felt ignored until the finger lifted — on a fast runner that is a death.

## Fix

- `SWIPE_THRESHOLD` 80px → 30px, `SWIPE_VERTICAL_THRESHOLD` 60px → 25px (the ~25-35px band iOS/Android system gestures use).
- New `touchmove` handler fires `_onLaneChange`/`_onJump` as soon as the threshold is crossed, honoring the existing debounce and `_acceptsGameplayInput()` gate.
- `_touchGestureConsumed` prevents `touchend` re-firing the same gesture. The tap-zone fallback still runs for gestures that never crossed threshold.
- `removeTouch()` unregisters the new listener.

## Tests

5 new cases in `tests/InputManager.test.ts`: resolves on touchmove not touchend, no double-fire, vertical jump on touchmove, teardown removes the listener, gate blocks touchmove swipes, tap-zone fallback intact.

`bun run typecheck` clean, `bun test` green.

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)