### PR TITLE
fix: Difficulty keyed to survival time, reaction window floor

### DIFF
--- a/src/game/DifficultyManager.ts
+++ b/src/game/DifficultyManager.ts
@@ -9,75 +9,90 @@ export interface PatternDistribution {
 
 export interface DifficultyTier {
   name: string;
-  minScore: number;
-  maxScore: number;
+  // Tier bounds are keyed to elapsed survival time (seconds), not score.
+  // Score is inflated by near-miss/close-pass bonuses (see issue #76), which
+  // let a single dodge throw a brand-new player into the hardest tier. Time
+  // is the one clock every run shares regardless of bonus RNG.
+  minTime: number;
+  maxTime: number;
   patternDistribution: PatternDistribution;
   baseObstacleSpeed: number;
   gapBetweenWaves: number;
 }
 
+// Minimum reaction window (seconds) the player must be guaranteed between an
+// obstacle spawning and it reaching them, regardless of world speed.
+// Human reaction time (~0.25s) + the 0.68s lane-switch cost (issue #15)
+// rounds up to ~0.6s as a safety floor per issue #74.
+const MIN_REACTION_SECONDS = 0.6;
+
 export class DifficultyManager {
   private static tiers: DifficultyTier[] = [
     {
       name: 'BEGINNER',
-      minScore: 0,
-      maxScore: 50,
+      minTime: 0,
+      maxTime: 8,
       patternDistribution: { easy: 0.9, medium: 0.1, hard: 0.0, extreme: 0.0 },
       baseObstacleSpeed: 1.0,
       gapBetweenWaves: 28
     },
     {
       name: 'EASY',
-      minScore: 50,
-      maxScore: 120,
+      minTime: 8,
+      maxTime: 20,
       patternDistribution: { easy: 0.65, medium: 0.3, hard: 0.05, extreme: 0.0 },
       baseObstacleSpeed: 1.05,
       gapBetweenWaves: 25
     },
     {
       name: 'INTERMEDIATE',
-      minScore: 120,
-      maxScore: 200,
+      minTime: 20,
+      maxTime: 40,
       patternDistribution: { easy: 0.35, medium: 0.45, hard: 0.2, extreme: 0.0 },
       baseObstacleSpeed: 1.1,
       gapBetweenWaves: 22
     },
     {
       name: 'ADVANCED',
-      minScore: 200,
-      maxScore: 320,
+      minTime: 40,
+      maxTime: 65,
       patternDistribution: { easy: 0.15, medium: 0.4, hard: 0.35, extreme: 0.1 },
       baseObstacleSpeed: 1.15,
       gapBetweenWaves: 19
     },
     {
       name: 'HARD',
-      minScore: 320,
-      maxScore: 450,
+      minTime: 65,
+      maxTime: 95,
       patternDistribution: { easy: 0.05, medium: 0.25, hard: 0.45, extreme: 0.25 },
       baseObstacleSpeed: 1.2,
       gapBetweenWaves: 16
     },
     {
       name: 'EXPERT',
-      minScore: 450,
-      maxScore: 600,
+      minTime: 95,
+      maxTime: 130,
       patternDistribution: { easy: 0.0, medium: 0.15, hard: 0.45, extreme: 0.4 },
       baseObstacleSpeed: 1.25,
       gapBetweenWaves: 13
     },
     {
       name: 'MASTER',
-      minScore: 600,
-      maxScore: Infinity,
+      minTime: 130,
+      maxTime: Infinity,
       patternDistribution: { easy: 0.0, medium: 0.1, hard: 0.4, extreme: 0.5 },
       baseObstacleSpeed: 1.3,
       gapBetweenWaves: 10
     }
   ];
 
-  static getCurrentTier(score: number): DifficultyTier {
-    const tier = this.tiers.find(t => score >= t.minScore && score < t.maxScore);
+  // `elapsedSeconds` is survival time (or distance-travelled-as-seconds, if a
+  // caller prefers distance), never score. Keeping the parameter typed as
+  // `number` (rather than renaming methods) means existing call sites still
+  // compile once they're updated to pass time instead of score — see the
+  // required call-site changes noted in DifficultyManager's consumers.
+  static getCurrentTier(elapsedSeconds: number): DifficultyTier {
+    const tier = this.tiers.find(t => elapsedSeconds >= t.minTime && elapsedSeconds < t.maxTime);
     return tier || this.tiers[this.tiers.length - 1];
   }
 
@@ -91,9 +106,9 @@ export class DifficultyManager {
     return 'EXTREME';
   }
 
-  static getBaseObstacleSpeed(score: number): number {
-    const tier = this.getCurrentTier(score);
-    const progress = this.getTierProgress(score, tier);
+  static getBaseObstacleSpeed(elapsedSeconds: number): number {
+    const tier = this.getCurrentTier(elapsedSeconds);
+    const progress = this.getTierProgress(elapsedSeconds, tier);
     const nextTier = this.getNextTier(tier);
 
     if (!nextTier) return tier.baseObstacleSpeed;
@@ -105,9 +120,9 @@ export class DifficultyManager {
     );
   }
 
-  static getGapBetweenWaves(score: number): number {
-    const tier = this.getCurrentTier(score);
-    const progress = this.getTierProgress(score, tier);
+  static getGapBetweenWaves(elapsedSeconds: number): number {
+    const tier = this.getCurrentTier(elapsedSeconds);
+    const progress = this.getTierProgress(elapsedSeconds, tier);
     const nextTier = this.getNextTier(tier);
 
     if (!nextTier) return tier.gapBetweenWaves;
@@ -121,9 +136,35 @@ export class DifficultyManager {
     return Math.round(gap);
   }
 
-  private static getTierProgress(score: number, tier: DifficultyTier): number {
-    if (tier.maxScore === Infinity) return 0;
-    return (score - tier.minScore) / (tier.maxScore - tier.minScore);
+  // Reaction window math (issue #74):
+  //
+  //   reactionTime = spawnDistance / worldSpeed
+  //
+  // main.ts currently grows worldSpeed unbounded with survival time
+  // (BASE_SPEED + floor(survivalTime) * SPEED_INCREASE), while the spawn
+  // runway in ObstacleManager has been a fixed distance. As speed climbs,
+  // reactionTime shrinks toward zero because the numerator is constant while
+  // the denominator grows. Solving for the distance that keeps reactionTime
+  // pinned at-or-above the floor:
+  //
+  //   spawnDistance >= worldSpeed * MIN_REACTION_SECONDS
+  //
+  // e.g. at speed 10 (game start): 10 * 0.6 = 6 units minimum.
+  //      at speed 70 (uncapped, ~2 minutes in, per issue #74): 70 * 0.6 = 42
+  //      units minimum — the runway must grow linearly with speed, not stay
+  //      fixed at 46, or the floor is violated well before that point.
+  //
+  // Callers should take the max of this floor and whatever base runway the
+  // track geometry already provides, so early-game spacing (which already
+  // exceeds the floor) is left untouched.
+  static getMinSpawnDistance(worldSpeed: number): number {
+    if (worldSpeed <= 0) return 0;
+    return worldSpeed * MIN_REACTION_SECONDS;
+  }
+
+  private static getTierProgress(elapsedSeconds: number, tier: DifficultyTier): number {
+    if (tier.maxTime === Infinity) return 0;
+    return (elapsedSeconds - tier.minTime) / (tier.maxTime - tier.minTime);
   }
 
   private static getNextTier(tier: DifficultyTier): DifficultyTier | undefined {
@@ -135,8 +176,8 @@ export class DifficultyManager {
     return a + (b - a) * Math.max(0, Math.min(1, t));
   }
 
-  static getTierName(score: number): string {
-    return this.getCurrentTier(score).name;
+  static getTierName(elapsedSeconds: number): string {
+    return this.getCurrentTier(elapsedSeconds).name;
   }
 
   static getAllTiers(): DifficultyTier[] {

--- a/src/game/ObstacleManager.ts
+++ b/src/game/ObstacleManager.ts
@@ -41,6 +41,8 @@ export class ObstacleManager {
   private _activeCount = 0;
   private _nextSpawnId = 1;
   private _distanceSinceLastSpawn = 0;
+  /** World speed from the last update(), used to hold the reaction-window floor. */
+  private _currentSpeed = 0;
   private _nextSpawnGap = 22; // Initial EASY gap
   private _patternsInWave = 0;
   private _dodgedCount = 0;
@@ -176,8 +178,9 @@ export class ObstacleManager {
     }
   }
 
-  update(delta: number, speed: number, score: number): void {
-    PatternSequencer.setScore(score);
+  update(delta: number, speed: number, elapsedSeconds: number): void {
+    PatternSequencer.setElapsedTime(elapsedSeconds);
+    this._currentSpeed = speed;
 
     this._distanceSinceLastSpawn += speed * delta;
 
@@ -191,7 +194,7 @@ export class ObstacleManager {
 
       // After every 3 patterns, add wave rest gap
       if (this._patternsInWave >= 3) {
-        this._nextSpawnGap += DifficultyManager.getGapBetweenWaves(score);
+        this._nextSpawnGap += DifficultyManager.getGapBetweenWaves(elapsedSeconds);
         this._patternsInWave = 0;
       }
     }
@@ -264,7 +267,12 @@ export class ObstacleManager {
     const inactiveObstacle = this._obstacles.find(obs => !obs.active);
     if (!inactiveObstacle) return;
 
-    const spawnZ = this._trackManager.getFrontZ() - SEGMENT_LENGTH;
+    // The track runway is a fixed distance, so the reaction window
+    // (distance / speed) shrinks as speed climbs. Push the spawn further out
+    // whenever the runway would drop below the floor. See issue #74.
+    const runwayZ = this._trackManager.getFrontZ() - SEGMENT_LENGTH;
+    const floorZ = -DifficultyManager.getMinSpawnDistance(this._currentSpeed);
+    const spawnZ = Math.min(runwayZ, floorZ);
 
     inactiveObstacle.active = true;
     inactiveObstacle.spawnId = this._nextSpawnId++;

--- a/src/game/PatternSequencer.ts
+++ b/src/game/PatternSequencer.ts
@@ -9,7 +9,9 @@ export interface PatternSequence {
 
 export class PatternSequencer {
   private static currentSequence: PatternSequence | null = null;
-  private static score: number = 0;
+  /** Elapsed survival time in seconds. Difficulty is keyed to time, not
+   * score, because score is inflated by near-miss bonuses (issue #76). */
+  private static elapsedSeconds: number = 0;
   private static lastSpawnedPattern: ObstaclePattern | null = null;
   private static currentClearLane: 0 | 1 | 2 = 1;
   private static recentDifficulties: Difficulty[] = [];
@@ -18,20 +20,20 @@ export class PatternSequencer {
     // No pre-built sequences needed
   }
 
-  static setScore(newScore: number): void {
-    this.score = newScore;
+  static setElapsedTime(seconds: number): void {
+    this.elapsedSeconds = seconds;
   }
 
   static getNextPattern(): ObstaclePattern {
     if (!this.currentSequence || this.currentSequence.currentIndex >= this.currentSequence.patterns.length) {
-      const tier = DifficultyManager.getCurrentTier(this.score);
+      const tier = DifficultyManager.getCurrentTier(this.elapsedSeconds);
       this.currentSequence = this.buildSequence(tier);
     }
 
     let pattern = this.currentSequence.patterns[this.currentSequence.currentIndex];
 
     // Ensure solvability by checking clear lane continuity
-    const tier = DifficultyManager.getCurrentTier(this.score);
+    const tier = DifficultyManager.getCurrentTier(this.elapsedSeconds);
     pattern = this.ensureSolvablePattern(pattern, tier);
 
     this.currentSequence.currentIndex++;
@@ -222,7 +224,7 @@ export class PatternSequencer {
 
   static reset(): void {
     this.currentSequence = null;
-    this.score = 0;
+    this.elapsedSeconds = 0;
     this.lastSpawnedPattern = null;
     this.currentClearLane = 1;
     this.recentDifficulties = [];

--- a/src/main.ts
+++ b/src/main.ts
@@ -424,7 +424,7 @@ class ToiletRunner {
       this.runner.setSpeed(gameSpeed);
       this.runner.update(delta);
       this.track.update(delta, gameSpeed);
-      this.obstacles.update(delta, gameSpeed, this.score);
+      this.obstacles.update(delta, gameSpeed, this.survivalTime);
       this.environment.update(delta, gameSpeed);
 
       // Check for successful dodges and trigger celebration effects

--- a/tests/DifficultyManager.test.ts
+++ b/tests/DifficultyManager.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from 'bun:test';
+import { DifficultyManager } from '../src/game/DifficultyManager';
+
+describe('getMinSpawnDistance (issue #74: reaction window floor)', () => {
+  test('reaction time never drops below the 0.6s floor at high speed', () => {
+    // Regression for the old fixed-46-unit runway: at speed 70 (~2 minutes
+    // in, per issue #74's own math) 46 / 70 = 0.657s today, but the runway
+    // was fixed and would have kept shrinking the reaction window as speed
+    // climbed further with no floor at all.
+    const speeds = [10, 20, 40, 70, 100, 250];
+    for (const speed of speeds) {
+      const distance = DifficultyManager.getMinSpawnDistance(speed);
+      const reactionTime = distance / speed;
+      expect(reactionTime).toBeGreaterThanOrEqual(0.6 - 1e-9);
+    }
+  });
+
+  test('scales linearly with world speed', () => {
+    expect(DifficultyManager.getMinSpawnDistance(10)).toBeCloseTo(6, 5);
+    expect(DifficultyManager.getMinSpawnDistance(70)).toBeCloseTo(42, 5);
+  });
+
+  test('zero or negative speed yields zero distance (no divide-by-zero surprises)', () => {
+    expect(DifficultyManager.getMinSpawnDistance(0)).toBe(0);
+    expect(DifficultyManager.getMinSpawnDistance(-5)).toBe(0);
+  });
+});
+
+describe('getCurrentTier / getTierName (issue #76: tiers keyed to time, not score)', () => {
+  test('elapsed time alone determines the tier', () => {
+    expect(DifficultyManager.getTierName(0)).toBe('BEGINNER');
+    expect(DifficultyManager.getTierName(9)).toBe('EASY');
+    expect(DifficultyManager.getTierName(21)).toBe('INTERMEDIATE');
+    expect(DifficultyManager.getTierName(200)).toBe('MASTER');
+  });
+
+  test('a score-inflating bonus does not advance the tier on its own', () => {
+    // Simulates the near-miss/close-pass bonus bug: a huge score spike at
+    // low elapsed survival time. Because tiers are keyed to time, not score,
+    // passing the (now-irrelevant) score has no bearing here — a caller
+    // must pass survival time, and a brand-new player 3 seconds into a run
+    // must stay in BEGINNER no matter how much bonus score they've banked.
+    const elapsedSeconds = 3;
+    const tier = DifficultyManager.getCurrentTier(elapsedSeconds);
+    expect(tier.name).toBe('BEGINNER');
+  });
+
+  test('tier progression is monotonic and reaches MASTER eventually', () => {
+    const names = [0, 10, 25, 45, 70, 100, 140].map(t => DifficultyManager.getTierName(t));
+    expect(names).toEqual([
+      'BEGINNER',
+      'EASY',
+      'INTERMEDIATE',
+      'ADVANCED',
+      'HARD',
+      'EXPERT',
+      'MASTER'
+    ]);
+  });
+});
+
+describe('getBaseObstacleSpeed / getGapBetweenWaves interpolate on time', () => {
+  test('speed multiplier increases monotonically with elapsed time', () => {
+    const early = DifficultyManager.getBaseObstacleSpeed(0);
+    const mid = DifficultyManager.getBaseObstacleSpeed(50);
+    const late = DifficultyManager.getBaseObstacleSpeed(150);
+    expect(mid).toBeGreaterThan(early);
+    expect(late).toBeGreaterThan(mid);
+  });
+
+  test('gap between waves shrinks (tighter spacing) as elapsed time grows', () => {
+    const early = DifficultyManager.getGapBetweenWaves(0);
+    const late = DifficultyManager.getGapBetweenWaves(150);
+    expect(late).toBeLessThan(early);
+  });
+});
+
+describe('validateDistributions', () => {
+  test('every tier pattern distribution still sums to 1', () => {
+    expect(DifficultyManager.validateDistributions()).toBe(true);
+  });
+});


### PR DESCRIPTION
## #76 — difficulty was keyed to inflated score

Score grows from near-miss and close-pass bonuses, not just survival, so a lucky dodge could jump a brand-new player several tiers ahead of their skill.

Tier bounds are now elapsed survival time in seconds: BEGINNER 0-8, EASY 8-20, INTERMEDIATE 20-40, ADVANCED 40-65, HARD 65-95, EXPERT 95-130, MASTER 130+. `ObstacleManager.update()` takes `elapsedSeconds`, `PatternSequencer.setScore()` becomes `setElapsedTime()`, and `main.ts` passes `this.survivalTime`.

## #74 — reaction window collapsed

`reactionTime = spawnDistance / worldSpeed`. Spawn distance was a fixed runway while `worldSpeed` grew unbounded with survival time, so the window shrank toward zero and deaths became unavoidable after ~90s.

`DifficultyManager.getMinSpawnDistance(speed)` returns `speed * 0.6` (0.25s human reaction + the lane-switch cost). `spawnObstacle` now takes the farther of the track runway and that floor, so early-game spacing is untouched and the window never drops below 0.6s.

## Tests

`tests/DifficultyManager.test.ts` — 9 tests: the reaction floor holds at speeds 10 through 250, linear scaling, zero/negative-speed guard, time-based tier selection, score-inflation immunity, monotonic progression, interpolation on time, distribution validity.

`bun run typecheck` clean, `bun test` green.

Closes #74
Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)