### PR TITLE
feat: Combo streak with score multiplier

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,6 +58,10 @@
        #sr-announcer instead. -->
   <div id="score-display" aria-hidden="true">0</div>
 
+  <!-- Combo streak / multiplier indicator. Not a live region for the same
+       reason as #score-display — it updates too often for a screen reader. -->
+  <div id="combo-display" aria-hidden="true"></div>
+
   <!-- Polite, low-frequency announcements for screen readers. -->
   <div id="sr-announcer" class="sr-only" role="status" aria-live="polite" aria-atomic="true"></div>
 

--- a/src/game/combo.ts
+++ b/src/game/combo.ts
@@ -1,0 +1,28 @@
+/**
+ * combo.ts - Pure functions for the combo streak/multiplier system.
+ *
+ * A "clean pass" (near-miss or close-pass dodge) increments the streak.
+ * A collision resets it to zero. The multiplier scales bonus score awarded
+ * for clean passes, so a long clean run pays out more than a sloppy one.
+ */
+
+/** Streak length required to reach each multiplier tier, ascending. */
+export const COMBO_THRESHOLDS: ReadonlyArray<{ streak: number; multiplier: number }> = [
+  { streak: 40, multiplier: 4 },
+  { streak: 20, multiplier: 3 },
+  { streak: 10, multiplier: 2 },
+  { streak: 5, multiplier: 1.5 },
+];
+
+/**
+ * Returns the score multiplier for a given streak length.
+ * Below the lowest threshold, the multiplier is 1 (no bonus).
+ */
+export function getComboMultiplier(streak: number): number {
+  for (const tier of COMBO_THRESHOLDS) {
+    if (streak >= tier.streak) {
+      return tier.multiplier;
+    }
+  }
+  return 1;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,7 @@ import { HUD } from './ui/HUD';
 import { TrailRenderer } from './game/TrailRenderer';
 import { SpeedLines } from './game/visual/SpeedLines';
 import { getScoreVerdict } from './game/ScoreVerdict';
+import { getComboMultiplier } from './game/combo';
 import { InstallPrompt } from './ui/InstallPrompt';
 
 const BASE_SPEED = 10;
@@ -445,22 +446,30 @@ class ToiletRunner {
           const lateralDist = Math.abs(obstacle.x - playerPos.x);
           const isNearMiss = lateralDist < NEAR_MISS_MAX_DIST && lateralDist > SAME_LANE_THRESHOLD;
 
-          if (isNearMiss) {
-            // Near miss - adjacent lane dodge (with coin magnet bonus)
-            const magnetBonus = this.shopManager.getCoinMagnetBonus();
-            const nearMissScore = NEAR_MISS_BONUS + magnetBonus;
-            const nearMissCoins = NEAR_MISS_COIN_REWARD + Math.floor(magnetBonus / 2);
-            this.score += nearMissScore;
-            this.dailyChallenges.updateCoinBalance(nearMissCoins);
-            this.ui.showScorePopup(`+${nearMissScore} Score +${nearMissCoins} Coins!`, true);
-            this.runner.triggerSuccessBounce();
-          } else if (lateralDist <= SAME_LANE_THRESHOLD) {
-            // Close pass - same lane, jumped over
-            const magnetBonus = this.shopManager.getCoinMagnetBonus();
-            const closePassCoins = CLOSE_PASS_COIN_REWARD + Math.floor(magnetBonus / 5);
-            this.score += CLOSE_PASS_BONUS;
-            this.dailyChallenges.updateCoinBalance(closePassCoins);
-            this.ui.showScorePopup(`+${CLOSE_PASS_BONUS} Score +${closePassCoins} Coins!`, false);
+          if (isNearMiss || lateralDist <= SAME_LANE_THRESHOLD) {
+            // Every clean dodge (near-miss or close-pass) extends the streak.
+            this.currentStreak++;
+            const comboMultiplier = getComboMultiplier(this.currentStreak);
+            this.hud.updateCombo(this.currentStreak, comboMultiplier);
+
+            if (isNearMiss) {
+              // Near miss - adjacent lane dodge (with coin magnet bonus)
+              const magnetBonus = this.shopManager.getCoinMagnetBonus();
+              const nearMissScore = Math.round((NEAR_MISS_BONUS + magnetBonus) * comboMultiplier);
+              const nearMissCoins = NEAR_MISS_COIN_REWARD + Math.floor(magnetBonus / 2);
+              this.score += nearMissScore;
+              this.dailyChallenges.updateCoinBalance(nearMissCoins);
+              this.ui.showScorePopup(`+${nearMissScore} Score +${nearMissCoins} Coins!`, true);
+              this.runner.triggerSuccessBounce();
+            } else {
+              // Close pass - same lane, jumped over
+              const magnetBonus = this.shopManager.getCoinMagnetBonus();
+              const closePassCoins = CLOSE_PASS_COIN_REWARD + Math.floor(magnetBonus / 5);
+              const closePassScore = Math.round(CLOSE_PASS_BONUS * comboMultiplier);
+              this.score += closePassScore;
+              this.dailyChallenges.updateCoinBalance(closePassCoins);
+              this.ui.showScorePopup(`+${closePassScore} Score +${closePassCoins} Coins!`, false);
+            }
           }
 
           // Trigger celebration effects for both near-miss and close-pass
@@ -598,6 +607,10 @@ class ToiletRunner {
     const obstaclePos = new THREE.Vector3(hitPos.x, hitPos.y, hitPos.z);
     for (let i = 0; i < 8; i++) {
       this.impactParticles.emitImpact(obstaclePos);
+    }
+    if (this.currentStreak > 0) {
+      this.currentStreak = 0;
+      this.hud.triggerComboBreak();
     }
   }
 

--- a/src/ui/HUD.ts
+++ b/src/ui/HUD.ts
@@ -13,6 +13,11 @@
 export class HUD {
   private _scoreElement: HTMLElement | null = null;
   private _scoreAnimator: any = null; // ScoreAnimator instance
+  private _comboElement: HTMLElement | null = null;
+  // Cached values so updateCombo() never writes to the DOM unless something
+  // actually changed.
+  private _lastStreak = -1;
+  private _lastMultiplier = -1;
 
   constructor() {
     this._scoreElement = document.getElementById('score-display');
@@ -20,6 +25,10 @@ export class HUD {
       console.warn('[HUD] Score display element not found');
     } else {
       this._applyEnhancedStyling();
+    }
+    this._comboElement = document.getElementById('combo-display');
+    if (!this._comboElement) {
+      console.warn('[HUD] Combo display element not found');
     }
   }
 
@@ -61,6 +70,53 @@ export class HUD {
       // Fallback: direct reset
       this._updateDirectScore(0);
     }
+    this._lastStreak = -1;
+    this._lastMultiplier = -1;
+    if (this._comboElement) {
+      this._comboElement.textContent = '';
+      this._comboElement.classList.remove('combo-break', 'combo-active');
+    }
+  }
+
+  /**
+   * Update the combo streak/multiplier display. No-ops (no DOM write) when
+   * neither value has changed since the last call, to avoid layout work on
+   * every frame.
+   */
+  public updateCombo(streak: number, multiplier: number): void {
+    if (!this._comboElement) return;
+    if (streak === this._lastStreak && multiplier === this._lastMultiplier) return;
+    this._lastStreak = streak;
+    this._lastMultiplier = multiplier;
+
+    if (streak <= 0) {
+      this._comboElement.textContent = '';
+      this._comboElement.classList.remove('combo-active');
+      return;
+    }
+
+    this._comboElement.textContent = multiplier > 1
+      ? `${streak}x Combo ×${multiplier}`
+      : `${streak}x Combo`;
+    this._comboElement.classList.add('combo-active');
+  }
+
+  /**
+   * Play a visible break animation when the streak resets due to a collision.
+   */
+  public triggerComboBreak(): void {
+    if (!this._comboElement) return;
+    this._comboElement.classList.remove('combo-break');
+    // Force reflow to restart animation
+    void this._comboElement.offsetWidth;
+    this._comboElement.classList.add('combo-break');
+    this._comboElement.classList.remove('combo-active');
+
+    setTimeout(() => {
+      if (this._comboElement) {
+        this._comboElement.classList.remove('combo-break');
+      }
+    }, 500);
   }
 
   /**

--- a/styles/base.css
+++ b/styles/base.css
@@ -75,6 +75,44 @@ html, body {
   transform: translateX(-50%) scale(1.15);
 }
 
+/* Combo Streak Display */
+#combo-display {
+  position: fixed;
+  top: calc(max(env(safe-area-inset-top, 20px), 20px) + 52px);
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: clamp(14px, 3vw, 18px);
+  font-weight: 700;
+  font-family: 'Poppins', sans-serif;
+  color: #ffd166;
+  text-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
+  z-index: 100;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+#combo-display.combo-active {
+  opacity: 1;
+}
+
+#combo-display.combo-break {
+  animation: combo-break-flash 0.5s ease;
+}
+
+@keyframes combo-break-flash {
+  0% {
+    opacity: 1;
+    color: #ff5d5d;
+    transform: translateX(-50%) scale(1.2);
+  }
+  100% {
+    opacity: 0;
+    color: #ff5d5d;
+    transform: translateX(-50%) scale(1);
+  }
+}
+
 /* Upgrade Indicators HUD */
 .upgrade-hud {
   position: fixed;

--- a/tests/ComboStreak.test.ts
+++ b/tests/ComboStreak.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test, beforeEach } from 'bun:test';
+import { getComboMultiplier, COMBO_THRESHOLDS } from '../src/game/combo';
+import { HUD } from '../src/ui/HUD';
+
+describe('getComboMultiplier', () => {
+  test('below the lowest threshold, multiplier is 1', () => {
+    expect(getComboMultiplier(0)).toBe(1);
+    expect(getComboMultiplier(4)).toBe(1);
+  });
+
+  test('boundary at streak 5 reaches 1.5x', () => {
+    expect(getComboMultiplier(5)).toBe(1.5);
+    expect(getComboMultiplier(9)).toBe(1.5);
+  });
+
+  test('boundary at streak 10 reaches 2x', () => {
+    expect(getComboMultiplier(10)).toBe(2);
+    expect(getComboMultiplier(19)).toBe(2);
+  });
+
+  test('boundary at streak 20 reaches 3x', () => {
+    expect(getComboMultiplier(20)).toBe(3);
+    expect(getComboMultiplier(39)).toBe(3);
+  });
+
+  test('boundary at streak 40 reaches 4x and stays capped beyond it', () => {
+    expect(getComboMultiplier(40)).toBe(4);
+    expect(getComboMultiplier(1000)).toBe(4);
+  });
+
+  test('thresholds are defined in descending streak order', () => {
+    for (let i = 1; i < COMBO_THRESHOLDS.length; i++) {
+      expect(COMBO_THRESHOLDS[i].streak).toBeLessThan(COMBO_THRESHOLDS[i - 1].streak);
+    }
+  });
+});
+
+describe('HUD combo display', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="score-display"></div><div id="combo-display"></div>';
+  });
+
+  test('updateCombo writes streak and multiplier text', () => {
+    const hud = new HUD();
+    hud.updateCombo(5, 1.5);
+    const el = document.getElementById('combo-display');
+    expect(el?.textContent).toContain('5');
+    expect(el?.classList.contains('combo-active')).toBe(true);
+  });
+
+  test('updateCombo does not touch the DOM when values are unchanged', () => {
+    const hud = new HUD();
+    hud.updateCombo(5, 1.5);
+    const el = document.getElementById('combo-display')!;
+    // Mutate a sentinel attribute directly; if updateCombo writes again with
+    // the same values it would not restore this, but textContent assignment
+    // would replace child nodes we can detect via object identity of the
+    // text node.
+    const textNodeBefore = el.firstChild;
+    hud.updateCombo(5, 1.5);
+    expect(el.firstChild).toBe(textNodeBefore);
+  });
+
+  test('updateCombo re-renders when the streak changes', () => {
+    const hud = new HUD();
+    hud.updateCombo(5, 1.5);
+    const el = document.getElementById('combo-display')!;
+    const textNodeBefore = el.firstChild;
+    hud.updateCombo(6, 1.5);
+    expect(el.firstChild).not.toBe(textNodeBefore);
+  });
+
+  test('reset clears the combo display and streak cache', () => {
+    const hud = new HUD();
+    hud.updateCombo(10, 2);
+    hud.reset();
+    const el = document.getElementById('combo-display');
+    expect(el?.textContent).toBe('');
+    expect(el?.classList.contains('combo-active')).toBe(false);
+  });
+
+  test('a zero streak clears the active class without leaving stale text', () => {
+    const hud = new HUD();
+    hud.updateCombo(5, 1.5);
+    hud.updateCombo(0, 1);
+    const el = document.getElementById('combo-display');
+    expect(el?.textContent).toBe('');
+    expect(el?.classList.contains('combo-active')).toBe(false);
+  });
+
+  test('triggerComboBreak adds and later removes the break animation class', async () => {
+    const hud = new HUD();
+    hud.updateCombo(10, 2);
+    hud.triggerComboBreak();
+    const el = document.getElementById('combo-display')!;
+    expect(el.classList.contains('combo-break')).toBe(true);
+    expect(el.classList.contains('combo-active')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

`main.ts` declared `currentStreak` and reset it on collision, but nothing ever incremented it. A clean ten-dodge run paid the same as a sloppy one — nothing accumulated that the player was afraid to lose, which is the genre's core compulsion hook.

## Change

- New `src/game/combo.ts` — pure `getComboMultiplier(streak)` over a `COMBO_THRESHOLDS` table: 5 → 1.5x, 10 → 2x, 20 → 3x, 40 → 4x (capped), 1x below 5.
- Streak increments inside the existing clean-pass branch (near-miss or close-pass), reusing that detection rather than adding a second path.
- The multiplier scales dodge bonuses only, not the passive per-second score, so totals stay readable.
- Collision resets the streak and fires `hud.triggerComboBreak()` (red flash, fade out).
- `HUD.updateCombo()` dirty-checks streak and multiplier, so no DOM write on an unchanged value.
- `#combo-display` styled to match `#score-display` (Poppins, same shadow, sits just under the score).

## Tests

`tests/ComboStreak.test.ts` — threshold boundaries at 5/10/20/40, sub-5 and above-cap, HUD no-op on unchanged value (verified by text node identity), re-render on change, `reset()` clearing, break-animation class handling.

`bun run typecheck` clean, `bun test` green (39 tests).

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)