### PR TITLE
feat: Add first-run tutorial and a permanent Controls screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,6 +129,10 @@
             <span class="btn-icon" aria-hidden="true">&#128202;</span>
             <span class="btn-text">Stats</span>
           </button>
+          <button id="controls-button" class="btn btn-nav menu-item" aria-label="Controls">
+            <span class="btn-icon" aria-hidden="true">&#127918;</span>
+            <span class="btn-text">Controls</span>
+          </button>
         </div>
         <div id="app-version" class="app-version"></div>
       </div>
@@ -287,6 +291,76 @@
       </div>
       <div class="modal-footer shop-footer">
         <button id="back-from-shop-button" class="btn btn-secondary menu-item">&larr; Back</button>
+      </div>
+    </div>
+
+    <!-- First-run "How to Play" Tutorial Overlay -->
+    <div class="modal modal-content" id="tutorial-screen" style="display: none;" role="dialog" aria-label="How to Play" aria-modal="true">
+      <div class="modal-header">
+        <h1>&#127918; How to Play</h1>
+      </div>
+      <div class="modal-body controls-body">
+        <ul class="controls-list" aria-label="Game controls">
+          <li class="control-row">
+            <span class="control-icon" aria-hidden="true">&#8592;&#8594;</span>
+            <span class="control-text">
+              <strong>Move</strong> &mdash; Arrow Left/Right or A/D &middot; swipe left/right
+            </span>
+          </li>
+          <li class="control-row">
+            <span class="control-icon" aria-hidden="true">&#8593;</span>
+            <span class="control-text">
+              <strong>Jump</strong> &mdash; Arrow Up, W, or Space &middot; swipe up
+            </span>
+          </li>
+          <li class="control-row">
+            <span class="control-icon" aria-hidden="true">&#9208;&#65039;</span>
+            <span class="control-text">
+              <strong>Pause</strong> &mdash; Pause button or Escape
+            </span>
+          </li>
+        </ul>
+      </div>
+      <div class="modal-footer">
+        <button id="tutorial-dismiss-button" class="btn btn-primary menu-item" aria-label="Got it, start playing">Got it!</button>
+      </div>
+    </div>
+
+    <!-- Controls Reference Screen -->
+    <div class="modal modal-content" id="controls-screen" style="display: none;" role="dialog" aria-label="Controls">
+      <div class="modal-header">
+        <h1>&#127918; Controls</h1>
+      </div>
+      <div class="modal-body controls-body">
+        <ul class="controls-list" aria-label="Game controls">
+          <li class="control-row">
+            <span class="control-icon" aria-hidden="true">&#8592;</span>
+            <span class="control-text">
+              <strong>Move Left</strong> &mdash; Arrow Left / A &middot; swipe left
+            </span>
+          </li>
+          <li class="control-row">
+            <span class="control-icon" aria-hidden="true">&#8594;</span>
+            <span class="control-text">
+              <strong>Move Right</strong> &mdash; Arrow Right / D &middot; swipe right
+            </span>
+          </li>
+          <li class="control-row">
+            <span class="control-icon" aria-hidden="true">&#8593;</span>
+            <span class="control-text">
+              <strong>Jump</strong> &mdash; Arrow Up, W, or Space &middot; swipe up
+            </span>
+          </li>
+          <li class="control-row">
+            <span class="control-icon" aria-hidden="true">&#9208;&#65039;</span>
+            <span class="control-text">
+              <strong>Pause</strong> &mdash; Pause button or Escape
+            </span>
+          </li>
+        </ul>
+      </div>
+      <div class="modal-footer controls-footer">
+        <button id="back-from-controls-button" class="btn btn-secondary menu-item">&larr; Back</button>
       </div>
     </div>
   </div>

--- a/src/core/GameState.ts
+++ b/src/core/GameState.ts
@@ -7,7 +7,8 @@ export enum GameState {
   SKINS,
   CHALLENGES,
   STATS,
-  SHOP
+  SHOP,
+  CONTROLS
 }
 
 export type GameStateValue = `${GameState}`;

--- a/src/core/StatsManager.ts
+++ b/src/core/StatsManager.ts
@@ -14,6 +14,7 @@ export interface PlayerStats {
   currentStreakDate: string;
   selectedSkin: string;
   unlockedSkins: string[];
+  tutorialSeen: boolean;
 }
 
 export interface SessionStats {
@@ -52,7 +53,9 @@ export class StatsManager {
       if (data) {
         const parsed: UnifiedData = JSON.parse(data);
         if (parsed.stats) {
-          return parsed.stats;
+          // Older saved blobs predate the tutorialSeen field - default to
+          // false so it behaves like any other unset boolean field.
+          return { ...parsed.stats, tutorialSeen: parsed.stats.tutorialSeen ?? false };
         }
       }
     } catch (e) {
@@ -76,7 +79,8 @@ export class StatsManager {
       currentStreak: 0,
       currentStreakDate: this._getTodayString(),
       selectedSkin: 'classic',
-      unlockedSkins: ['classic']
+      unlockedSkins: ['classic'],
+      tutorialSeen: false
     };
   }
 
@@ -301,6 +305,24 @@ export class StatsManager {
 
   public getSelectedSkin(): string {
     return this._stats.selectedSkin;
+  }
+
+  /**
+   * True once the player has dismissed the first-run "How to Play" overlay.
+   * Backed by the unified stats blob so the gate survives across sessions
+   * without a dedicated localStorage key.
+   */
+  public hasTutorialBeenSeen(): boolean {
+    return this._stats.tutorialSeen;
+  }
+
+  /** Marks the first-run tutorial as seen. Idempotent - a no-op after the first call. */
+  public markTutorialSeen(): void {
+    if (this._stats.tutorialSeen) {
+      return;
+    }
+    this._stats.tutorialSeen = true;
+    this._save();
   }
 
   public getFormattedPlayTime(): string {

--- a/src/main.ts
+++ b/src/main.ts
@@ -146,6 +146,10 @@ class ToiletRunner {
 
       this.ui.setGameState(this.currentGameState);
 
+      if (!this.statsManager.hasTutorialBeenSeen()) {
+        this.ui.showTutorialOverlay();
+      }
+
       this.ui.setDailyChallenges(this.dailyChallenges);
       this.ui.setStatsManager(this.statsManager);
 
@@ -348,6 +352,8 @@ class ToiletRunner {
     this.ui.setOnChallengesCallback(this.showChallengesScreen.bind(this));
     this.ui.setOnStatsCallback(this.showStatsScreen.bind(this));
     this.ui.setOnShopCallback(this.showShopScreen.bind(this));
+    this.ui.setOnControlsCallback(this.showControlsScreen.bind(this));
+    this.ui.setOnTutorialDismissCallback(this.dismissTutorial.bind(this));
 
     // Skin selection callback
     this.ui.setOnSelectSkinCallback((skinId: string) => {
@@ -846,6 +852,21 @@ class ToiletRunner {
     this.ui.setGameState(this.currentGameState);
     this.updateShopDisplay();
     this.analyticsManager.trackShopOpened(this.shopManager.getCoinBalance());
+  }
+
+  public showControlsScreen(): void {
+    this.currentGameState = GameState.CONTROLS;
+    this.ui.setGameState(this.currentGameState);
+  }
+
+  /**
+   * Dismisses the first-run tutorial overlay. Always returns to the start
+   * screen regardless of whether the flag was already set, so dismissing
+   * can never leave the play button unreachable.
+   */
+  private dismissTutorial(): void {
+    this.statsManager.markTutorialSeen();
+    this.ui.showStartScreen();
   }
 
   private updateShopDisplay(): void {

--- a/src/ui/ScreenManager.ts
+++ b/src/ui/ScreenManager.ts
@@ -14,14 +14,15 @@ export class ScreenManager {
 
   // Transition rules: Map of source states to allowed destination states
   private readonly _transitionRules: Map<GameState, GameState[]> = new Map([
-    [GameState.MENU, [GameState.PLAYING, GameState.SKINS, GameState.CHALLENGES, GameState.STATS, GameState.LEADERBOARD]],
+    [GameState.MENU, [GameState.PLAYING, GameState.SKINS, GameState.CHALLENGES, GameState.STATS, GameState.LEADERBOARD, GameState.CONTROLS]],
     [GameState.PLAYING, [GameState.PAUSED, GameState.GAMEOVER]],
     [GameState.PAUSED, [GameState.PLAYING, GameState.MENU]],
     [GameState.GAMEOVER, [GameState.MENU, GameState.PLAYING, GameState.LEADERBOARD]],
     [GameState.LEADERBOARD, [GameState.MENU]],
     [GameState.SKINS, [GameState.MENU]],
     [GameState.CHALLENGES, [GameState.MENU]],
-    [GameState.STATS, [GameState.MENU]]
+    [GameState.STATS, [GameState.MENU]],
+    [GameState.CONTROLS, [GameState.MENU]]
   ]);
 
   constructor() {

--- a/src/ui/UIManager.ts
+++ b/src/ui/UIManager.ts
@@ -50,6 +50,8 @@ export class UIManager {
   private _onChallenges: (() => void) | null = null;
   private _onStats: (() => void) | null = null;
   private _onShop: (() => void) | null = null;
+  private _onControls: (() => void) | null = null;
+  private _onTutorialDismiss: (() => void) | null = null;
   private _onSelectSkin: ((skinId: string) => void) | null = null;
   private _onPurchaseUpgrade: ((upgradeId: string) => void) | null = null;
   private _onSubmitName: ((name: string) => void) | null = null;
@@ -160,7 +162,17 @@ export class UIManager {
       if (tag === 'input' || tag === 'textarea' || target?.isContentEditable) return;
 
       if (e.key === 'Escape') {
-        if (this.currentGameState === GameState.GAMEOVER) {
+        const tutorialScreen = document.getElementById('tutorial-screen');
+        // Test the positive marker `_showScreen` sets. Absence of `hidden` is
+        // not the same thing: the markup ships without that class, so a stray
+        // Escape before the first `hideAllScreens()` would fire this branch.
+        if (tutorialScreen && tutorialScreen.classList.contains('visible')) {
+          if (this._onTutorialDismiss) this._onTutorialDismiss();
+          return;
+        }
+        if (this.currentGameState === GameState.CONTROLS) {
+          if (this._onBackToMenu) this._onBackToMenu();
+        } else if (this.currentGameState === GameState.GAMEOVER) {
           if (this._onRestart) this._onRestart();
         } else if (this.currentGameState === GameState.LEADERBOARD) {
           if (this._onBackToGameOver) this._onBackToGameOver();
@@ -182,6 +194,7 @@ export class UIManager {
           const isNavigationButton = target.closest('#skins-button') ||
                                     target.closest('#challenges-button') ||
                                     target.closest('#stats-button') ||
+                                    target.closest('#controls-button') ||
                                     target.closest('#play-button') ||
                                     target.closest('.skin-card') ||
                                     target.closest('.challenge-item') ||
@@ -242,6 +255,30 @@ export class UIManager {
         e.stopImmediatePropagation();
         if (this._onStats) {
           this._onStats();
+        }
+      });
+    }
+
+    // Controls button handler
+    const controlsButton = document.getElementById('controls-button');
+    if (controlsButton) {
+      controlsButton.addEventListener('click', (e: Event) => {
+        e.stopPropagation();
+        e.stopImmediatePropagation();
+        if (this._onControls) {
+          this._onControls();
+        }
+      });
+    }
+
+    // Tutorial dismiss button handler
+    const tutorialDismissButton = document.getElementById('tutorial-dismiss-button');
+    if (tutorialDismissButton) {
+      tutorialDismissButton.addEventListener('click', (e: Event) => {
+        e.stopPropagation();
+        e.stopImmediatePropagation();
+        if (this._onTutorialDismiss) {
+          this._onTutorialDismiss();
         }
       });
     }
@@ -324,6 +361,17 @@ export class UIManager {
     const backFromShopButton = document.getElementById('back-from-shop-button');
     if (backFromShopButton) {
       backFromShopButton.addEventListener('click', (e: Event) => {
+        e.stopPropagation();
+        e.stopImmediatePropagation();
+        if (this._onBackToMenu) {
+          this._onBackToMenu();
+        }
+      });
+    }
+
+    const backFromControlsButton = document.getElementById('back-from-controls-button');
+    if (backFromControlsButton) {
+      backFromControlsButton.addEventListener('click', (e: Event) => {
         e.stopPropagation();
         e.stopImmediatePropagation();
         if (this._onBackToMenu) {
@@ -444,6 +492,14 @@ export class UIManager {
     this._showScreen('shop-screen');
   }
 
+  public showControlsScreen(): void {
+    this._showScreen('controls-screen');
+  }
+
+  public showTutorialOverlay(): void {
+    this._showScreen('tutorial-screen');
+  }
+
   private _showScreen(screenId: string): void {
     this.hideAllScreens();
     const screen = document.getElementById(screenId);
@@ -479,7 +535,7 @@ export class UIManager {
     ];
     cachedElements.forEach(el => this._hideElement(el));
 
-    const screenIds = ['skin-screen', 'challenges-screen', 'stats-screen', 'shop-screen'];
+    const screenIds = ['skin-screen', 'challenges-screen', 'stats-screen', 'shop-screen', 'controls-screen', 'tutorial-screen'];
     screenIds.forEach(id => this._hideElement(document.getElementById(id)));
 
     if (this._pauseButtonContainer) {
@@ -630,6 +686,14 @@ export class UIManager {
 
   public setOnShopCallback(callback: () => void): void {
     this._onShop = callback;
+  }
+
+  public setOnControlsCallback(callback: () => void): void {
+    this._onControls = callback;
+  }
+
+  public setOnTutorialDismissCallback(callback: () => void): void {
+    this._onTutorialDismiss = callback;
   }
 
   public setOnSelectSkinCallback(callback: (skinId: string) => void): void {
@@ -1009,6 +1073,10 @@ export class UIManager {
         break;
       case GameState.SHOP:
         this.showShopScreen();
+        this.hidePauseButton();
+        break;
+      case GameState.CONTROLS:
+        this.showControlsScreen();
         this.hidePauseButton();
         break;
       default:

--- a/styles/modals.css
+++ b/styles/modals.css
@@ -1849,3 +1849,45 @@ button:focus-visible {
     justify-content: center;
   }
 }
+
+/* Controls / How-to-Play screens */
+.controls-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.control-row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+  background: linear-gradient(135deg, rgba(135, 206, 235, 0.1) 0%, rgba(93, 173, 226, 0.1) 100%);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-md);
+}
+
+.control-row .control-icon {
+  font-size: 28px;
+  flex-shrink: 0;
+  width: 40px;
+  text-align: center;
+}
+
+.control-row .control-text {
+  font-size: 14px;
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
+.control-row .control-text strong {
+  color: var(--primary-dark);
+  font-weight: 700;
+}
+
+.controls-footer {
+  display: flex;
+  justify-content: center;
+}

--- a/tests/Tutorial.test.ts
+++ b/tests/Tutorial.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test, beforeEach } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { StatsManager } from '../src/core/StatsManager';
+import { UIManager } from '../src/ui/UIManager';
+
+const REQUIRED_IDS = [
+  'start-screen', 'pause-screen', 'overlay', 'score-display',
+  'game-over-screen', 'final-score', 'restart-button', 'pause-btn',
+  'pause-button', 'resume-button', 'leaderboard-screen',
+  'leaderboard-list-full', 'view-leaderboard-button', 'back-to-game-over-button'
+];
+
+function mountShell(): void {
+  document.body.innerHTML = REQUIRED_IDS
+    .map(id => `<div id="${id}"></div>`)
+    .join('');
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('StatsManager tutorial gate', () => {
+  test('has not been seen on a fresh install', () => {
+    const stats = new StatsManager();
+    expect(stats.hasTutorialBeenSeen()).toBe(false);
+  });
+
+  test('marking seen flips the flag and persists it to the unified blob', () => {
+    const stats = new StatsManager();
+    stats.markTutorialSeen();
+    expect(stats.hasTutorialBeenSeen()).toBe(true);
+
+    // A fresh StatsManager instance re-reads localStorage - this simulates the
+    // player reloading the page or starting a new session.
+    const reloaded = new StatsManager();
+    expect(reloaded.hasTutorialBeenSeen()).toBe(true);
+  });
+
+  test('does not show again on the second run once dismissed once', () => {
+    const first = new StatsManager();
+    expect(first.hasTutorialBeenSeen()).toBe(false);
+    first.markTutorialSeen();
+
+    const second = new StatsManager();
+    expect(second.hasTutorialBeenSeen()).toBe(true);
+  });
+
+  test('is stored under the existing unified data key, not a bespoke one', () => {
+    const stats = new StatsManager();
+    stats.markTutorialSeen();
+
+    const raw = localStorage.getItem('toiletRunner_unifiedData');
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw as string);
+    expect(parsed.stats.tutorialSeen).toBe(true);
+    expect(localStorage.getItem('toiletRunner_tutorialSeen')).toBeNull();
+  });
+
+  test('an older saved blob without tutorialSeen defaults to not-seen rather than throwing', () => {
+    localStorage.setItem('toiletRunner_unifiedData', JSON.stringify({
+      version: 2,
+      stats: {
+        totalRuns: 3,
+        highestScore: 100,
+        totalDistance: 50,
+        totalObstaclesDodged: 2,
+        longestRun: 100,
+        totalPlayTime: 60,
+        gamesToday: 1,
+        lastPlayDate: '2020-01-01',
+        challengesCompleted: 0,
+        currentStreak: 0,
+        currentStreakDate: '2020-01-01',
+        selectedSkin: 'classic',
+        unlockedSkins: ['classic']
+        // tutorialSeen intentionally absent - simulates pre-existing save data
+      },
+      metadata: { lastUpdated: '2020-01-01', migratedFrom: [] }
+    }));
+
+    const stats = new StatsManager();
+    expect(stats.hasTutorialBeenSeen()).toBe(false);
+    expect(stats.getHighestScore()).toBe(100);
+  });
+});
+
+describe('Controls screen', () => {
+  beforeEach(mountShell);
+
+  // The real fragment from index.html, so these tests fail if the shipped
+  // markup drops a control rather than passing against a hand-rolled stub.
+  function controlsFragment(): string {
+    const html = readFileSync(new URL('../index.html', import.meta.url), 'utf-8');
+    const match = html.match(/<div [^>]*id="controls-screen"[\s\S]*?<\/div>\s*<\/div>\s*<\/div>/);
+    expect(match).not.toBeNull();
+    return match![0];
+  }
+
+  test('lists jump alongside the other controls, with both key and touch bindings', () => {
+    document.body.innerHTML += controlsFragment();
+    const ui = new UIManager();
+    ui.showControlsScreen();
+
+    const screen = document.getElementById('controls-screen');
+    expect(screen?.classList.contains('hidden')).toBe(false);
+
+    const rows = Array.from(screen!.querySelectorAll('.control-row')).map(r => r.textContent ?? '');
+    const jumpRow = rows.find(t => /Jump/i.test(t));
+    expect(jumpRow).toBeDefined();
+    // Discovering jump is the whole point of the screen, so it must name a key
+    // and a gesture, not just the word "Jump".
+    expect(jumpRow).toMatch(/Space/i);
+    expect(jumpRow).toMatch(/swipe up/i);
+    expect(rows.some(t => /Move Left/i.test(t))).toBe(true);
+    expect(rows.some(t => /Move Right/i.test(t))).toBe(true);
+    expect(rows.some(t => /Pause/i.test(t))).toBe(true);
+  });
+});


### PR DESCRIPTION
Supersedes #118, which GitHub auto-closed when its base branch `feat/combo-streak` was deleted on merge of #117. Same commit, rebased onto `main`.

- First-run tutorial overlay, gated on a new `tutorialSeen` flag in the unified `StatsManager` blob (backward compatible: older saves default to not-seen).
- Permanent Controls screen so jump/lane/pause bindings stay discoverable after the tutorial is dismissed.
- Escape dismisses the tutorial, keyed off the positive `visible` class.
- `tests/Tutorial.test.ts`: 6 tests covering the persistence gate and the real `index.html` controls markup.

Closes #78