### PR TITLE
chore: bump version to 1.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toilet-runner",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "3D endless runner with toilet paper roll avoiding poop obstacles",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Release bump for v1.12.0. Ships the full P1 backlog (#69-#78).

Verified on production before tagging: barrier unjumpable at apex, no all-lanes-blocked spawns across 21 barrier waves, combo HUD populates and clears, lanes land exactly on -3/0/+3 after the GameConfig consolidation, console clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)