### PR TITLE
fix: version-tagged analytics, clickable audio toggle, readable horizon

### DIFF
--- a/src/core/AnalyticsManager.ts
+++ b/src/core/AnalyticsManager.ts
@@ -21,7 +21,10 @@ export class AnalyticsManager {
   private _sessionStartTime: number = 0;
   private _events: AnalyticsEvent[] = [];
   private _isInitialized: boolean = false;
-  private _gameVersion: string = '1.6.0';
+  // Vite substitutes package.json's version at build time. The literal that
+  // used to live here froze at 1.6.0, so any event tracked before
+  // initialize() runs was tagged with a version the build had long left behind.
+  private _gameVersion: string = __APP_VERSION__;
   
   constructor() {
     this._loadPersistedData();

--- a/src/core/SceneManager.ts
+++ b/src/core/SceneManager.ts
@@ -2,6 +2,21 @@ import * as THREE from 'three';
 
 const PIXEL_RATIO_MAX = 2;
 
+/**
+ * Horizon colour, shared by the fog and the clear colour so the far end of the
+ * corridor and the sky behind it are the same shade — any mismatch draws a
+ * visible band across the skyline.
+ *
+ * This used to be 0x87CEEB (sky blue) with a fog range of 30-120. Obstacles
+ * spawn ~90 units from the camera, so they entered the scene already ~80%
+ * fogged into near-white glare and only resolved once they were close, eating
+ * into the reaction window. Darker colour plus a pushed-back near plane so a
+ * brown obstacle reads against the corridor for its whole approach.
+ */
+const HORIZON_COLOR = 0x4a6d8c;
+const FOG_NEAR = 45;
+const FOG_FAR = 130;
+
 export class SceneManager {
   private scene: THREE.Scene;
   private camera: THREE.PerspectiveCamera;
@@ -19,7 +34,7 @@ export class SceneManager {
 
   private createScene(): THREE.Scene {
     const scene = new THREE.Scene();
-    scene.fog = new THREE.Fog(0x87CEEB, 30, 120);
+    scene.fog = new THREE.Fog(HORIZON_COLOR, FOG_NEAR, FOG_FAR);
     return scene;
   }
 
@@ -37,7 +52,7 @@ export class SceneManager {
       powerPreference: 'high-performance',
       alpha: true
     });
-    renderer.setClearColor(0x87CEEB, 1);
+    renderer.setClearColor(HORIZON_COLOR, 1);
 
     const pixelRatio = Math.min(window.devicePixelRatio, PIXEL_RATIO_MAX);
     renderer.setPixelRatio(pixelRatio);

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,0 +1,7 @@
+/**
+ * Build-time constants injected by Vite's `define` (see vite.config.ts).
+ *
+ * Declared globally rather than per-module so a second consumer cannot drift
+ * by hardcoding its own copy of the version string.
+ */
+declare const __APP_VERSION__: string;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,5 @@
 import '../styles/modals.css';
 
-declare const __APP_VERSION__: string;
-
 import * as THREE from 'three';
 import { SceneManager } from './core/SceneManager';
 import { GameLoop } from './core/GameLoop';

--- a/src/style.css
+++ b/src/style.css
@@ -16,7 +16,9 @@ body {
   left: 0;
   width: 100vw;
   height: 100vh;
-  background-color: #87CEEB;
+  /* Must track HORIZON_COLOR in SceneManager.ts — the renderer is created with
+     alpha: true, so this shows through wherever the scene does not paint. */
+  background-color: #4a6d8c;
 }
 
 #canvas, #canvas canvas {

--- a/styles/intro.css
+++ b/styles/intro.css
@@ -253,7 +253,8 @@
   position: fixed;
   top: max(16px, env(safe-area-inset-top));
   right: max(16px, env(safe-area-inset-right));
-  z-index: 1000;
+  /* z-index lives in modals.css — that sheet loads later and its
+     .audio-controls rule wins the cascade at equal specificity. */
   width: 48px;
   height: 48px;
   background: linear-gradient(135deg, var(--primary-dark) 0%, var(--primary) 100%);

--- a/styles/modals.css
+++ b/styles/modals.css
@@ -476,7 +476,10 @@
   box-shadow: 0 4px 12px rgba(255, 215, 0, 0.4);
   touch-action: manipulation;
   transition: transform 0.15s ease, box-shadow 0.15s ease;
-  z-index: 1000;
+  /* Above .start-screen (9999) and .modal-overlay (9998). At 1000 the start
+     screen painted straight over this button, so the only mute control in the
+     game was unclickable on the first screen the player sees. */
+  z-index: 10001;
 }
 
 .audio-controls:hover {


### PR DESCRIPTION
Closes #67, #121, #123.

## What

| Issue | Fix |
|---|---|
| #67 | `AnalyticsManager` hardcoded game version `'1.6.0'`. Now reads Vite's `__APP_VERSION__`, declared once in `src/globals.d.ts`. |
| #121 | Audio toggle unclickable on start screen — z-index 1000 vs `.start-screen` 9999. Raised to 10001 in `modals.css` (the sheet that wins the cascade). |
| #123 | Blown-out white horizon hid obstacles until close. Horizon colour `0x4a6d8c`, fog near pushed 30 → 45. |

`setClearColor` and the CSS body background track the same `HORIZON_COLOR` — the renderer uses `alpha: true`, so a mismatch draws a band across the skyline.

## Verification

- `bun run typecheck` clean
- `bun run test` — 84 pass / 0 fail
- `bun run build` clean
- Browser: audio toggle clicks through on the start screen and flips 🔊/🔇; obstacles read against the corridor at spawn distance; tutorial, start screen, gameplay, and game over all render; console clean apart from the dev-only Vite HMR websocket warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)