### PR TITLE
feat: measure device capability instead of sniffing the user agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,10 @@ A humorous 3D endless runner where a toilet paper roll runs forward, avoiding pi
 
 ## Performance Optimizations
 
+- **Measured quality tier:** A GPU-synced boot benchmark grades the device and picks LOW/MEDIUM/HIGH. No user-agent sniffing — a fast phone gets the same effects a fast laptop does.
+- **Adaptive quality:** `AdaptiveQuality` watches delivered frame times during play and drops a tier after 3s below 45 FPS, climbing back after 8s above 58 FPS (5s cooldown between changes). Thermal throttling and background tabs get corrected mid-run.
 - **InstancedMesh:** 1 draw call for 50+ obstacles
-- **Pixel ratio:** Clamped to 2x on mobile
+- **Pixel ratio:** Clamped to 2x, tier-selected
 - **Object pooling:** Reduce GC pressure
 - **Fog:** Hide distant geometry
 - **Simple materials:** MeshLambertMaterial (not PBR)

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -192,17 +192,60 @@ is the enum. Pause is the one binding that works outside active play, so
 
 <h2>Performance design</h2>
 <p>
-<code>PerformanceManager</code> runs a short WebGL benchmark on startup and picks a tier.
+<code>PerformanceManager</code> measures the device at startup and picks a tier.
 Everything downstream (particle budgets, post-processing, pixel ratio) reads from the tier.
+There is no user-agent sniffing anywhere in the path: a phone is graded on what it
+renders, not on what its UA string says it is.
+</p>
+<p>
+The boot benchmark draws a rotating <code>TorusKnot</code> at a fixed 512×512 with the same
+<code>MeshLambertMaterial</code> + <code>HemisphereLight</code> setup the game shades with. Warm-up
+frames run first, then a timed loop, with <code>gl.readPixels()</code> before and after to force
+the GPU to drain — without that sync point the loop only measures how fast JS can queue
+commands, not how fast the GPU executes them. The resulting FPS is normalised by the
+device's real pixel load (<code>viewport × devicePixelRatio²</code>) to estimate native FPS,
+the same approach <code>detect-gpu</code> uses. The whole benchmark is budgeted at 250&nbsp;ms.
 </p>
 <table>
   <thead><tr><th>Tier</th><th>Selected when</th><th>Collision particles</th><th>Effect particles</th><th>Pixel ratio</th></tr></thead>
   <tbody>
-    <tr><td>LOW</td><td>bench score &lt; 20, or no/soft WebGL</td><td>15</td><td>0</td><td>1</td></tr>
-    <tr><td>MEDIUM</td><td>score 20–39 (also the default)</td><td>25</td><td>15</td><td>1.5</td></tr>
-    <tr><td>HIGH</td><td>score ≥ 40</td><td>40</td><td>25</td><td>2</td></tr>
+    <tr><td>LOW</td><td>est. native FPS &lt; 30, or no WebGL / software renderer</td><td>15</td><td>0</td><td>1</td></tr>
+    <tr><td>MEDIUM</td><td>30–54</td><td>25</td><td>15</td><td>1.5</td></tr>
+    <tr><td>HIGH</td><td>≥ 55</td><td>40</td><td>25</td><td>2</td></tr>
   </tbody>
 </table>
+<p>
+<code>deviceMemory &lt; 2</code> caps a HIGH verdict at MEDIUM. Players can override the whole
+thing: <code>PerformanceManager.setPreference()</code> pins a tier and disables adaptation,
+persisted under <code>toiletRunner_quality</code> (a key separate from the unified stats blob,
+because a tier has to be chosen before <code>StatsManager</code> has loaded).
+</p>
+
+<h3>Adaptive quality</h3>
+<p>
+A boot benchmark can only guess. A phone that benchmarks well still throttles when it warms
+up, and a desktop is fine until another tab wants the GPU. <code>AdaptiveQuality</code> watches
+the frames actually delivered during <code>PLAYING</code> and corrects the guess at runtime.
+Hysteresis keeps it from oscillating:
+</p>
+<table>
+  <thead><tr><th>Transition</th><th>Threshold</th><th>Window</th></tr></thead>
+  <tbody>
+    <tr><td>Downgrade</td><td>avg &lt; 45 FPS</td><td>3 s</td></tr>
+    <tr><td>Upgrade</td><td>avg &gt; 58 FPS</td><td>8 s</td></tr>
+    <tr><td>Cooldown after any change</td><td>—</td><td>5 s</td></tr>
+  </tbody>
+</table>
+<p>
+Upgrades need a longer look than downgrades: being briefly too conservative costs some
+sparkle, being briefly too ambitious costs frames mid-run, which is what a player actually
+notices in a reaction-time game. The boot verdict is the ceiling — adaptation can recover
+ground it gave up but never promote a device past what it measured. Frames longer than
+0.25&nbsp;s (tab-switch, GC pause) are discarded rather than counted, so one hitch cannot drop
+everyone's quality. Telemetry is suspended outside gameplay so an idle menu is not mistaken
+for headroom. A downgrade tears down post-processing; an upgrade does not rebuild it, since
+recompiling shaders would stall exactly the frames the upgrade was meant to reward.
+</p>
 <ul>
   <li><strong>InstancedMesh</strong> for track segments and obstacles — target &lt;10 draw calls, &lt;10K triangles.</li>
   <li><strong>Object pooling</strong> for obstacles; no per-frame allocations in hot loops. Reuse
@@ -287,7 +330,7 @@ Vite is configured with <code>base: './'</code> — required for GitHub Pages as
 </table>
 
 <footer>
-  Last updated 2026-08-10 · <a href="../README.md">README</a> ·
+  Last updated 2026-08-11 · <a href="../README.md">README</a> ·
   <a href="https://bigknoxy.github.io/toilet-runner/">Play</a>
 </footer>
 

--- a/src/core/AdaptiveQuality.ts
+++ b/src/core/AdaptiveQuality.ts
@@ -1,0 +1,147 @@
+/**
+ * Runtime frame-rate watchdog that decides when the graphics tier should move.
+ *
+ * A boot-time benchmark can only ever guess. A phone that benchmarks well still
+ * throttles once it warms up, and a desktop can be fine until another tab starts
+ * competing for the GPU. This watches the frames actually being delivered and
+ * reacts to them, which is the only measurement that reflects what the player
+ * is really seeing.
+ *
+ * Deliberately tier-agnostic: it works on integer tier indices (0 = lowest) so
+ * there is no import edge back to PerformanceManager, and so it can be unit
+ * tested without a WebGL context.
+ *
+ * Time is accumulated from the deltas the caller feeds in rather than read from
+ * performance.now(). That keeps the state machine deterministic in tests and
+ * keeps it aligned with the same capped delta the game loop uses for physics.
+ */
+export class AdaptiveQuality {
+  /** Sustained average below this drops a tier. */
+  static readonly DOWNGRADE_FPS = 45;
+  /** Sustained average above this climbs a tier, up to the boot-detected ceiling. */
+  static readonly UPGRADE_FPS = 58;
+  /** Seconds of history required before a downgrade can fire. */
+  static readonly DOWNGRADE_WINDOW = 3;
+  /**
+   * Upgrades need a longer look than downgrades. Being briefly too conservative
+   * costs the player some sparkle; being briefly too ambitious costs them frames
+   * mid-run, which is what they actually notice in a reaction-time game.
+   */
+  static readonly UPGRADE_WINDOW = 8;
+  /** Quiet period after any tier change, so one change cannot immediately trigger the next. */
+  static readonly COOLDOWN = 5;
+  /**
+   * Frames longer than this are a tab-switch, a GC pause, or an alt-tab - not a
+   * signal about sustained rendering cost. Counting them would let a single
+   * hitch drop everyone's quality, so they are discarded entirely.
+   */
+  static readonly MAX_PLAUSIBLE_DELTA = 0.25;
+
+  /** Retained history. Slightly longer than UPGRADE_WINDOW so that window is always coverable. */
+  private static readonly HISTORY = AdaptiveQuality.UPGRADE_WINDOW * 1.25;
+
+  private _now = 0;
+  private _times: number[] = [];
+  private _deltas: number[] = [];
+  private _tier: number;
+  private _ceiling: number;
+  private _cooldownUntil: number;
+
+  /**
+   * @param startTier Tier index chosen by the boot benchmark.
+   * @param ceiling   Highest tier this session may climb back to. Defaults to
+   *                  startTier: the benchmark's verdict is treated as an upper
+   *                  bound, so adaptation can only recover ground it gave up,
+   *                  never promote a device past what it measured.
+   */
+  constructor(startTier: number, ceiling: number = startTier) {
+    this._tier = startTier;
+    this._ceiling = Math.max(startTier, ceiling);
+    // Startup is the worst time to judge: shaders are still compiling, textures
+    // are uploading, and the first GC has not happened yet.
+    this._cooldownUntil = AdaptiveQuality.COOLDOWN;
+  }
+
+  get tier(): number {
+    return this._tier;
+  }
+
+  /**
+   * Feed one frame. Returns the new tier index if it changed this frame,
+   * otherwise null.
+   */
+  update(delta: number): number | null {
+    if (delta <= 0 || delta > AdaptiveQuality.MAX_PLAUSIBLE_DELTA) return null;
+
+    this._now += delta;
+    this._times.push(this._now);
+    this._deltas.push(delta);
+    this._prune();
+
+    if (this._now < this._cooldownUntil) return null;
+
+    const recent = this._averageFps(AdaptiveQuality.DOWNGRADE_WINDOW);
+    if (recent !== null && recent < AdaptiveQuality.DOWNGRADE_FPS && this._tier > 0) {
+      return this._change(this._tier - 1);
+    }
+
+    const sustained = this._averageFps(AdaptiveQuality.UPGRADE_WINDOW);
+    if (sustained !== null && sustained > AdaptiveQuality.UPGRADE_FPS && this._tier < this._ceiling) {
+      return this._change(this._tier + 1);
+    }
+
+    return null;
+  }
+
+  /** Drop samples the longest window no longer needs. */
+  private _prune(): void {
+    const cutoff = this._now - AdaptiveQuality.HISTORY;
+    let drop = 0;
+    while (drop < this._times.length && this._times[drop] <= cutoff) drop++;
+    if (drop > 0) {
+      this._times.splice(0, drop);
+      this._deltas.splice(0, drop);
+    }
+  }
+
+  /**
+   * Average FPS over the trailing `window` seconds, or null when history does
+   * not yet span it. Returning null rather than a partial average is what stops
+   * a half-second of stutter during a state transition from moving the tier.
+   */
+  private _averageFps(window: number): number | null {
+    const cutoff = this._now - window;
+    if (this._times.length === 0 || this._times[0] > cutoff) return null;
+
+    let frames = 0;
+    let elapsed = 0;
+    for (let i = this._times.length - 1; i >= 0; i--) {
+      if (this._times[i] <= cutoff) break;
+      frames++;
+      elapsed += this._deltas[i];
+    }
+    return elapsed > 0 ? frames / elapsed : null;
+  }
+
+  private _change(next: number): number {
+    this._tier = next;
+    this._cooldownUntil = this._now + AdaptiveQuality.COOLDOWN;
+    // History describes rendering at the old tier, so it says nothing about
+    // whether the new one holds up. Starting clean also means the next decision
+    // has to re-earn a full window of evidence.
+    this._times.length = 0;
+    this._deltas.length = 0;
+    return next;
+  }
+
+  /**
+   * Forget accumulated history without touching the tier. Called when the player
+   * leaves gameplay, so an idle menu (which renders almost nothing) cannot be
+   * mistaken for headroom.
+   */
+  reset(): void {
+    this._times.length = 0;
+    this._deltas.length = 0;
+    this._cooldownUntil = this._now + AdaptiveQuality.COOLDOWN;
+  }
+}

--- a/src/core/PerformanceManager.ts
+++ b/src/core/PerformanceManager.ts
@@ -1,6 +1,20 @@
 import * as THREE from 'three';
+import { AdaptiveQuality } from './AdaptiveQuality';
 
 export enum PerformanceTier {
+  LOW = 'low',
+  MEDIUM = 'medium',
+  HIGH = 'high'
+}
+
+/**
+ * What the player asked for in settings. AUTO hands the decision to the
+ * benchmark plus the runtime watchdog; anything else pins the tier and disables
+ * adaptation, because a player who picked LOW to save battery does not want the
+ * game quietly promoting itself back to HIGH.
+ */
+export enum QualityPreference {
+  AUTO = 'auto',
   LOW = 'low',
   MEDIUM = 'medium',
   HIGH = 'high'
@@ -16,75 +30,243 @@ export interface PerformanceConfig {
   emojiFaces: boolean;
 }
 
+/** Lowest to highest. Index order is what AdaptiveQuality operates on. */
+const TIER_ORDER: PerformanceTier[] = [
+  PerformanceTier.LOW,
+  PerformanceTier.MEDIUM,
+  PerformanceTier.HIGH
+];
+
+/**
+ * Benchmark render target size. Fixed rather than matched to the window so the
+ * raw score means the same thing on every device; the device's real pixel load
+ * is applied afterwards in _estimateNativeFps().
+ */
+const BENCH_SIZE = 512;
+/** Frames rendered before timing starts, to pay for shader compile and buffer upload. */
+const BENCH_WARMUP_FRAMES = 10;
+const BENCH_FRAMES = 60;
+/** Hard ceiling on how long the player waits at a black screen for this. */
+const BENCH_BUDGET_MS = 250;
+
+const PIXEL_RATIO_CAP = 2;
+
+/**
+ * Settings live under their own key rather than inside `toiletRunner_unifiedData`.
+ * That blob is versioned player *stats* with its own migration path, and it is
+ * loaded by StatsManager well after PerformanceManager.initialize() has already
+ * had to pick a tier. A separate key removes the ordering hazard.
+ */
+const QUALITY_STORAGE_KEY = 'toiletRunner_quality';
+
 export class PerformanceManager {
   private static tier: PerformanceTier = PerformanceTier.MEDIUM;
-  private static currentFPS: number = 60;
+  /** Highest tier the boot benchmark judged this device capable of. */
+  private static ceiling: PerformanceTier = PerformanceTier.MEDIUM;
+  private static preference: QualityPreference = QualityPreference.AUTO;
+  private static adaptive: AdaptiveQuality | null = null;
+  private static onTierChange: ((config: PerformanceConfig) => void) | null = null;
   private static fpsSamples: number[] = [];
 
   static async initialize(): Promise<PerformanceConfig> {
-    await this.detectCapabilities();
+    this.preference = this.loadPreference();
+
+    if (this.preference === QualityPreference.AUTO) {
+      await this.detectCapabilities();
+    } else {
+      this.tier = this.preference as unknown as PerformanceTier;
+      this.ceiling = this.tier;
+    }
+
+    this.adaptive = new AdaptiveQuality(
+      TIER_ORDER.indexOf(this.tier),
+      TIER_ORDER.indexOf(this.ceiling)
+    );
+
     return this.getConfig();
   }
 
+  // ---------------------------------------------------------------- detection
+
   private static async detectCapabilities(): Promise<void> {
     const canvas = document.createElement('canvas');
-    const gl = canvas.getContext('webgl2');
-    
+    const gl = canvas.getContext('webgl2') || canvas.getContext('webgl');
+
     if (!gl) {
-      this.tier = PerformanceTier.LOW;
+      this.setDetected(PerformanceTier.LOW);
       return;
     }
 
-    const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
-    const hasLowMemory = (navigator as any).deviceMemory && (navigator as any).deviceMemory < 4;
+    // A software rasteriser will happily render everything, just slowly enough
+    // to be unplayable. This is the one renderer-string check worth making;
+    // parsing actual GPU model names is a losing game (the string is absent
+    // under Firefox's resistFingerprinting and randomised by privacy
+    // extensions), so everything else is left to the benchmark.
+    if (this.isSoftwareRenderer(gl)) {
+      this.setDetected(PerformanceTier.LOW);
+      return;
+    }
 
-    if (isMobile || hasLowMemory) {
-      this.tier = PerformanceTier.LOW;
-    } else {
-      const score = await this.runQuickBenchmark();
-      if (score < 20) this.tier = PerformanceTier.LOW;
-      else if (score < 40) this.tier = PerformanceTier.MEDIUM;
-      else this.tier = PerformanceTier.HIGH;
+    const score = await this.runBenchmark();
+
+    let tier: PerformanceTier;
+    // Thresholds are an estimated sustained framerate at this device's native
+    // resolution. They are a starting guess on purpose - AdaptiveQuality
+    // corrects a wrong one within a few seconds of real gameplay, which is why
+    // this no longer needs to be conservative about unknown hardware.
+    if (score >= 55) tier = PerformanceTier.HIGH;
+    else if (score >= 30) tier = PerformanceTier.MEDIUM;
+    else tier = PerformanceTier.LOW;
+
+    // deviceMemory is a coarse, Chromium-only hint. Treated as a ceiling rather
+    // than a verdict: a 2GB device can still render fine, but headroom for
+    // post-processing render targets is genuinely tight.
+    const deviceMemory = (navigator as unknown as { deviceMemory?: number }).deviceMemory;
+    if (deviceMemory !== undefined && deviceMemory < 2 && tier === PerformanceTier.HIGH) {
+      tier = PerformanceTier.MEDIUM;
+    }
+
+    this.setDetected(tier);
+  }
+
+  private static setDetected(tier: PerformanceTier): void {
+    this.tier = tier;
+    this.ceiling = tier;
+  }
+
+  private static isSoftwareRenderer(gl: WebGLRenderingContext | WebGL2RenderingContext): boolean {
+    try {
+      const ext = gl.getExtension('WEBGL_debug_renderer_info');
+      if (!ext) return false;
+      const renderer = String(gl.getParameter(ext.UNMASKED_RENDERER_WEBGL) ?? '');
+      return /swiftshader|llvmpipe|software|basic render/i.test(renderer);
+    } catch {
+      // Blocked by privacy settings. Absence of the string is not evidence of
+      // anything, so fall through and let the benchmark decide.
+      return false;
     }
   }
 
-  private static async runQuickBenchmark(): Promise<number> {
-    const renderer = new THREE.WebGLRenderer({ antialias: false });
-    renderer.setSize(100, 100);
-
+  /**
+   * Estimated sustained FPS at this device's native render resolution.
+   *
+   * The previous version of this timed 50 bare `renderer.render()` calls at
+   * 100x100. WebGL commands are queued asynchronously, so that loop returned
+   * before the GPU had drawn anything - it measured JavaScript call overhead and
+   * nothing else, which is why a flagship phone and a 2015 tablet scored alike.
+   * This version draws real fill at a fixed size and blocks on readPixels so the
+   * elapsed time actually includes GPU work.
+   */
+  private static async runBenchmark(): Promise<number> {
+    let renderer: THREE.WebGLRenderer | null = null;
+    const geometry = new THREE.TorusKnotGeometry(0.6, 0.25, 128, 32);
+    // Lambert to match what the game actually shades with, so the benchmark
+    // exercises a comparable fragment cost rather than a flat unlit fill.
+    const material = new THREE.MeshLambertMaterial({ color: 0xcccccc });
     const scene = new THREE.Scene();
-    const camera = new THREE.PerspectiveCamera(75, 1, 0.1, 1000);
-
-    const geometry = new THREE.TorusKnotGeometry(0.5, 0.2, 64, 8);
-    const material = new THREE.MeshBasicMaterial();
     const mesh = new THREE.Mesh(geometry, material);
-    scene.add(mesh);
+    const camera = new THREE.PerspectiveCamera(75, 1, 0.1, 100);
 
-    const startTime = performance.now();
-    const iterations = 50;
+    try {
+      renderer = new THREE.WebGLRenderer({ antialias: false, powerPreference: 'high-performance' });
+      renderer.setPixelRatio(1);
+      renderer.setSize(BENCH_SIZE, BENCH_SIZE);
 
-    for (let i = 0; i < iterations; i++) {
-      mesh.rotation.x += 0.1;
-      mesh.rotation.y += 0.1;
-      renderer.render(scene, camera);
+      scene.add(mesh);
+      scene.add(new THREE.HemisphereLight(0xffffff, 0x444444, 1));
+      camera.position.z = 2;
+
+      const gl = renderer.getContext();
+      const sync = new Uint8Array(4);
+      // readPixels stalls the CPU until the GPU has drained its queue. Without
+      // it every timing below would be measuring command submission again.
+      const drain = () => gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, sync);
+
+      for (let i = 0; i < BENCH_WARMUP_FRAMES; i++) {
+        mesh.rotation.x += 0.1;
+        renderer.render(scene, camera);
+      }
+      drain();
+
+      const start = performance.now();
+      let frames = 0;
+      while (frames < BENCH_FRAMES) {
+        mesh.rotation.x += 0.1;
+        mesh.rotation.y += 0.1;
+        renderer.render(scene, camera);
+        frames++;
+        // Bail out on slow hardware rather than making it wait the longest.
+        if (frames % 10 === 0 && performance.now() - start > BENCH_BUDGET_MS) break;
+      }
+      drain();
+      const elapsed = performance.now() - start;
+
+      if (elapsed <= 0) return 0;
+      const benchFps = (frames / elapsed) * 1000;
+      return this.estimateNativeFps(benchFps);
+    } catch {
+      // A failed benchmark is not a fast device. Assume the worst and let the
+      // runtime watchdog promote it if gameplay proves otherwise.
+      return 0;
+    } finally {
+      geometry.dispose();
+      material.dispose();
+      scene.clear();
+      if (renderer) {
+        renderer.dispose();
+        renderer.forceContextLoss();
+        renderer.domElement.remove();
+      }
     }
-
-    const score = (iterations / (performance.now() - startTime)) * 1000;
-
-    renderer.dispose();
-    geometry.dispose();
-    material.dispose();
-    mesh.removeFromParent();
-    scene.remove(mesh);
-    renderer.domElement.remove();
-
-    return score;
   }
 
+  /**
+   * Scale the fixed-resolution benchmark result by how many more (or fewer)
+   * pixels this device actually has to fill. A phone at devicePixelRatio 3 can
+   * post a great score at 512x512 and still miss 60fps on its own screen.
+   */
+  private static estimateNativeFps(benchFps: number): number {
+    const dpr = Math.min(window.devicePixelRatio || 1, PIXEL_RATIO_CAP);
+    const nativePixels = window.innerWidth * window.innerHeight * dpr * dpr;
+    if (nativePixels <= 0) return benchFps;
+    return benchFps * ((BENCH_SIZE * BENCH_SIZE) / nativePixels);
+  }
+
+  // ------------------------------------------------------------- adaptation
+
+  /**
+   * Register the callback that applies a live tier change. Only the knobs that
+   * are safe to change mid-run are re-applied (pixel ratio, post-processing);
+   * particle budgets and material quality are baked in at construction and stay
+   * at whatever the boot tier chose.
+   */
+  static setOnTierChange(callback: (config: PerformanceConfig) => void): void {
+    this.onTierChange = callback;
+  }
+
+  /**
+   * Feed one gameplay frame. Must only be called while actually playing - menus
+   * render almost nothing and would read as free headroom.
+   */
   static updateFPS(delta: number): void {
-    const fps = Math.round(1 / delta);
+    const fps = delta > 0 ? Math.round(1 / delta) : 60;
     this.fpsSamples.push(fps);
     if (this.fpsSamples.length > 30) this.fpsSamples.shift();
+
+    if (!this.adaptive || this.preference !== QualityPreference.AUTO) return;
+
+    const next = this.adaptive.update(delta);
+    if (next === null) return;
+
+    this.tier = TIER_ORDER[next];
+    this.fpsSamples = [];
+    this.onTierChange?.(this.getConfig());
+  }
+
+  /** Discard frame history when leaving gameplay. */
+  static suspendAdaptation(): void {
+    this.adaptive?.reset();
+    this.fpsSamples = [];
   }
 
   static getAverageFPS(): number {
@@ -93,6 +275,60 @@ export class PerformanceManager {
       this.fpsSamples.reduce((a, b) => a + b, 0) / this.fpsSamples.length
     );
   }
+
+  // ------------------------------------------------------------- preference
+
+  static getPreference(): QualityPreference {
+    return this.preference;
+  }
+
+  /**
+   * Apply a settings change. Returns the config to render with. Switching to
+   * AUTO restores the benchmark's verdict rather than re-running it - a second
+   * benchmark mid-session would fight with whatever else is on screen.
+   */
+  static setPreference(preference: QualityPreference): PerformanceConfig {
+    this.preference = preference;
+
+    if (preference === QualityPreference.AUTO) {
+      this.tier = this.ceiling;
+    } else {
+      this.tier = preference as unknown as PerformanceTier;
+    }
+
+    this.adaptive = new AdaptiveQuality(
+      TIER_ORDER.indexOf(this.tier),
+      TIER_ORDER.indexOf(this.ceiling)
+    );
+
+    try {
+      localStorage.setItem(QUALITY_STORAGE_KEY, preference);
+    } catch {
+      // Private browsing or a full quota. The setting just will not persist.
+    }
+
+    const config = this.getConfig();
+    this.onTierChange?.(config);
+    return config;
+  }
+
+  private static loadPreference(): QualityPreference {
+    try {
+      const stored = localStorage.getItem(QUALITY_STORAGE_KEY);
+      if (
+        stored === QualityPreference.LOW ||
+        stored === QualityPreference.MEDIUM ||
+        stored === QualityPreference.HIGH
+      ) {
+        return stored;
+      }
+    } catch {
+      // localStorage unavailable; AUTO is the right fallback anyway.
+    }
+    return QualityPreference.AUTO;
+  }
+
+  // ------------------------------------------------------------------ config
 
   static getConfig(): PerformanceConfig {
     switch (this.tier) {
@@ -122,7 +358,7 @@ export class PerformanceManager {
           shadows: true,
           postProcessing: true,
           particles: { collision: 40, effects: 25 },
-          pixelRatio: 2,
+          pixelRatio: PIXEL_RATIO_CAP,
           antialias: true,
           emojiFaces: true
         };

--- a/src/core/SceneManager.ts
+++ b/src/core/SceneManager.ts
@@ -126,6 +126,15 @@ export class SceneManager {
     return this.renderer;
   }
 
+  /**
+   * The constructor has to pick a pixel ratio before the performance tier is
+   * known, so it uses the device maximum. This re-applies the tier's choice once
+   * PerformanceManager has decided, and again on any later tier change.
+   */
+  public setPixelRatio(ratio: number): void {
+    this.renderer.setPixelRatio(Math.min(ratio, PIXEL_RATIO_MAX));
+  }
+
   public resize(width: number, height: number): void {
     this.camera.aspect = width / height;
     this.camera.updateProjectionMatrix();

--- a/src/game/visual/PostProcessingManager.ts
+++ b/src/game/visual/PostProcessingManager.ts
@@ -11,6 +11,13 @@ interface PostProcessingConfig {
   bloom?: { strength: number; threshold: number; radius: number };
   fxaa?: boolean;
   vignette?: { offset: number; darkness: number };
+  /**
+   * Multiplier on the bloom render target size. Bloom is the most fill-rate
+   * hungry pass here, so weaker devices render it at half size and let the
+   * upscale hide it. Previously decided by sniffing the user agent, which meant
+   * every phone got the cheap path no matter how fast it was.
+   */
+  bloomResolutionScale?: number;
 }
 
 export class PostProcessingManager {
@@ -35,7 +42,10 @@ export class PostProcessingManager {
     } = await import('three/examples/jsm/postprocessing/EffectComposer.js');
 
     this.composer = new Composer(this.renderer);
-    this.composer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    // Match the renderer rather than always maxing out: the tier already
+    // decided how many pixels this device should be asked to fill, and the
+    // composer running hotter than the renderer wastes exactly that saving.
+    this.composer.setPixelRatio(this.renderer.getPixelRatio());
 
     const {
       RenderPass
@@ -49,10 +59,10 @@ export class PostProcessingManager {
         'three/examples/jsm/postprocessing/UnrealBloomPass.js'
       );
 
-      const isMobile = /Android|iPhone|iPad/i.test(navigator.userAgent);
+      const scale = config.bloomResolutionScale ?? 1;
       const bloomResolution = new THREE.Vector2(
-        isMobile ? window.innerWidth * 0.5 : window.innerWidth,
-        isMobile ? window.innerHeight * 0.5 : window.innerHeight
+        window.innerWidth * scale,
+        window.innerHeight * scale
       );
 
       this.bloomPass = new UnrealBloomPass(
@@ -81,8 +91,11 @@ export class PostProcessingManager {
       this.composer.addPass(this.fxaaPass);
     }
 
-    // Add vignette effect (desktop only for performance)
-    if (config.vignette && !this.isMobile()) {
+    // Whether to run the vignette is the caller's decision, made from the
+    // performance tier. It used to be gated on a user-agent test, so a capable
+    // phone lost the effect purely for being a phone while the same GPU class
+    // in a laptop kept it.
+    if (config.vignette) {
       this.vignettePass = new ShaderPass(VignetteShader);
       this.vignettePass.uniforms['offset'].value = config.vignette.offset;
       this.vignettePass.uniforms['darkness'].value = config.vignette.darkness;
@@ -121,9 +134,6 @@ export class PostProcessingManager {
     return this.composer !== null;
   }
 
-  private isMobile(): boolean {
-    return /Android|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
-  }
 }
 
 // Vignette shader for post-processing effect

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ import { SceneManager } from './core/SceneManager';
 import { GameLoop } from './core/GameLoop';
 import { GameState } from './core/GameState';
 import { LeaderboardManager } from './core/LeaderboardManager';
-import { PerformanceManager, PerformanceTier } from './core/PerformanceManager';
+import { PerformanceManager, PerformanceTier, PerformanceConfig } from './core/PerformanceManager';
 import { RunnerController } from './game/RunnerController';
 import { TrackManager } from './game/TrackManager';
 import { ObstacleManager } from './game/ObstacleManager';
@@ -63,7 +63,7 @@ const CLOSE_PASS_COIN_REWARD = 2;
 class ToiletRunner {
   private sceneManager!: SceneManager;
   private gameLoop!: GameLoop;
-  private performanceConfig: any;
+  private performanceConfig!: PerformanceConfig;
 
   private runner!: RunnerController;
   private track!: TrackManager;
@@ -126,6 +126,8 @@ class ToiletRunner {
       this.gameLoop = new GameLoop();
 
       this.performanceConfig = await PerformanceManager.initialize();
+      this.sceneManager.setPixelRatio(this.performanceConfig.pixelRatio);
+      PerformanceManager.setOnTierChange((config) => this.applyTierChange(config));
 
       this.setupGameLogic();
       this.setupUIAndInput();
@@ -265,6 +267,8 @@ class ToiletRunner {
   private setupPostProcessing(): void {
     if (!this.performanceConfig.postProcessing) return;
 
+    const isHigh = this.performanceConfig.tier === PerformanceTier.HIGH;
+
     this.postProcessing.initialize({
       enabled: true,
       bloom: {
@@ -272,14 +276,36 @@ class ToiletRunner {
         threshold: 0.9,
         radius: 0.3
       },
+      // Bloom at half size on MEDIUM keeps the glow without paying full fill
+      // rate for it. Both this and the vignette used to key off the user agent,
+      // which is why a fast phone looked flatter than a slow laptop.
+      bloomResolutionScale: isHigh ? 1 : 0.5,
       fxaa: true,
-      vignette: {
-        offset: 0.5,
-        darkness: 0.3
-      }
+      vignette: isHigh ? { offset: 0.5, darkness: 0.3 } : undefined
     });
 
     this.sceneManager.setPostProcessing(this.postProcessing);
+  }
+
+  /**
+   * Apply a tier change without restarting the run.
+   *
+   * Only the knobs that are cheap and safe to change mid-frame move here.
+   * Particle budgets, material quality and emoji faces are baked in when their
+   * systems are constructed, so they keep whatever the boot tier chose; tearing
+   * those down mid-run would cost more frames than it saves. Post-processing is
+   * dropped on the way down but not rebuilt on the way up, because rebuilding
+   * the composer compiles shaders and would stall the very frames the upgrade
+   * was meant to reward.
+   */
+  private applyTierChange(config: PerformanceConfig): void {
+    this.performanceConfig = config;
+    this.sceneManager.setPixelRatio(config.pixelRatio);
+
+    if (!config.postProcessing && this.postProcessing.isEnabled()) {
+      this.postProcessing.dispose();
+      this.sceneManager.setPostProcessing(null);
+    }
   }
 
   private setupGameLogic(): void {
@@ -388,7 +414,14 @@ class ToiletRunner {
   }
 
   private update(delta: number): void {
-    PerformanceManager.updateFPS(delta);
+    // Only gameplay frames are evidence. A paused or menu frame renders almost
+    // nothing, so counting those would read as headroom and talk the adaptive
+    // watchdog into a tier the actual run cannot hold.
+    if (this.currentGameState === GameState.PLAYING) {
+      PerformanceManager.updateFPS(delta);
+    } else {
+      PerformanceManager.suspendAdaptation();
+    }
 
     if (this.currentGameState === GameState.PLAYING) {
       // Death slow-motion sequence

--- a/tests/AdaptiveQuality.test.ts
+++ b/tests/AdaptiveQuality.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from 'bun:test';
+import { AdaptiveQuality } from '../src/core/AdaptiveQuality';
+
+const FAST = 1 / 60;
+const SLOW = 1 / 30;
+
+/**
+ * Feed `seconds` worth of frames at a fixed delta and return the first tier
+ * change reported, or null. Returning the first rather than the last matters:
+ * the tests are about *when* a change fires, so a later change would mask an
+ * early one.
+ */
+function run(aq: AdaptiveQuality, seconds: number, delta: number): number | null {
+  let first: number | null = null;
+  const frames = Math.round(seconds / delta);
+  for (let i = 0; i < frames; i++) {
+    const change = aq.update(delta);
+    if (change !== null && first === null) first = change;
+  }
+  return first;
+}
+
+describe('AdaptiveQuality', () => {
+  test('boot cooldown blocks any change during the first seconds', () => {
+    const aq = new AdaptiveQuality(2);
+    // Well past the 3s downgrade window but still inside the 5s cooldown.
+    expect(run(aq, AdaptiveQuality.COOLDOWN - 0.5, SLOW)).toBeNull();
+    expect(aq.tier).toBe(2);
+  });
+
+  test('sustained slow frames drop exactly one tier', () => {
+    const aq = new AdaptiveQuality(2);
+    expect(run(aq, 10, SLOW)).toBe(1);
+    expect(aq.tier).toBe(1);
+  });
+
+  test('downgrade needs a full window, not a single slow frame', () => {
+    const aq = new AdaptiveQuality(2);
+    run(aq, AdaptiveQuality.COOLDOWN + 1, FAST);
+    // One slow frame inside an otherwise fast history must not move the tier.
+    expect(aq.update(SLOW)).toBeNull();
+    expect(aq.tier).toBe(2);
+  });
+
+  test('cooldown prevents back-to-back downgrades', () => {
+    const aq = new AdaptiveQuality(2);
+    run(aq, 10, SLOW);
+    expect(aq.tier).toBe(1);
+    // A second drop would need another cooldown plus another full window.
+    // Just under that, so the tier must still be 1.
+    const aq2 = new AdaptiveQuality(2);
+    run(aq2, AdaptiveQuality.COOLDOWN + AdaptiveQuality.DOWNGRADE_WINDOW + 0.5, SLOW);
+    expect(aq2.tier).toBe(1);
+  });
+
+  test('fast frames climb back up but never past the ceiling', () => {
+    const aq = new AdaptiveQuality(0, 2);
+    expect(run(aq, 30, FAST)).toBe(1);
+    expect(aq.tier).toBe(2);
+    // Already at the ceiling: more fast frames change nothing.
+    expect(run(aq, 30, FAST)).toBeNull();
+    expect(aq.tier).toBe(2);
+  });
+
+  test('default ceiling is the start tier, so a healthy device never promotes', () => {
+    const aq = new AdaptiveQuality(1);
+    expect(run(aq, 30, FAST)).toBeNull();
+    expect(aq.tier).toBe(1);
+  });
+
+  test('tier 0 cannot drop below zero', () => {
+    const aq = new AdaptiveQuality(0);
+    expect(run(aq, 30, SLOW)).toBeNull();
+    expect(aq.tier).toBe(0);
+  });
+
+  test('implausible deltas are discarded, not counted as slow frames', () => {
+    const aq = new AdaptiveQuality(2);
+    run(aq, AdaptiveQuality.COOLDOWN + 1, FAST);
+    // A 2s tab-switch hitch. Counting it would tank the average instantly.
+    expect(aq.update(2)).toBeNull();
+    expect(aq.update(0)).toBeNull();
+    expect(aq.update(-1)).toBeNull();
+    expect(aq.tier).toBe(2);
+    // History still reads as fast, so no downgrade follows either.
+    expect(run(aq, 5, FAST)).toBeNull();
+    expect(aq.tier).toBe(2);
+  });
+
+  test('reset clears history and re-arms the cooldown without moving the tier', () => {
+    const aq = new AdaptiveQuality(2);
+    run(aq, AdaptiveQuality.COOLDOWN + 2, SLOW);
+    expect(aq.tier).toBe(1);
+
+    aq.reset();
+    expect(aq.tier).toBe(1);
+    // Freshly re-armed cooldown swallows a window that would otherwise downgrade.
+    expect(run(aq, AdaptiveQuality.COOLDOWN - 0.5, SLOW)).toBeNull();
+    expect(aq.tier).toBe(1);
+  });
+
+  test('an upgrade has to earn the full upgrade window, not just the cooldown', () => {
+    const aq = new AdaptiveQuality(0, 2);
+    // Cooldown expires at COOLDOWN, but promotion also needs UPGRADE_WINDOW of
+    // history. Stopping short of that must leave the tier alone.
+    expect(run(aq, AdaptiveQuality.UPGRADE_WINDOW - 0.5, FAST)).toBeNull();
+    expect(aq.tier).toBe(0);
+  });
+});


### PR DESCRIPTION
## Why

The screen-edge vignette shows on desktop but not on phones. That was not a design choice — `PostProcessingManager` had an `isMobile()` user-agent test gating it, and bloom resolution too.

Pulling that thread found worse things underneath:

1. **Every mobile device was pinned to LOW** before any measurement ran. A flagship phone and a five-year-old budget device got identical treatment.
2. **The boot benchmark measured nothing real.** `renderer.render()` queues GPU commands and returns immediately, so timing a render loop without a sync point measures JS submission overhead, not GPU work. The scores it produced were noise.
3. **Per-frame FPS telemetry was already being collected and never read by anything.**

## What changed

**Measure instead of predict.** `PerformanceManager.runBenchmark()` renders a fixed 512×512 rotating `TorusKnot` using the same `MeshLambertMaterial` + `HemisphereLight` the game actually shades with, runs warm-up frames before timing, and calls `gl.readPixels()` to stall the CPU until the GPU drains. Result is normalised by the device's real pixel load (`viewport × dpr²`) to estimate native FPS — the method `detect-gpu` uses. Budgeted at 250 ms.

| Tier | Selected when |
|---|---|
| LOW | est. FPS < 30, or no WebGL / software renderer |
| MEDIUM | 30–54 |
| HIGH | ≥ 55 |

`deviceMemory < 2` caps HIGH at MEDIUM. Software renderers (SwiftShader/llvmpipe) short-circuit to LOW. `WEBGL_debug_renderer_info` is treated as a hint only — Firefox `resistFingerprinting` and privacy extensions block or randomise it.

**Correct the guess at runtime.** New `AdaptiveQuality` reads delivered frame times during `PLAYING`:

| Transition | Threshold | Window |
|---|---|---|
| Downgrade | avg < 45 FPS | 3 s |
| Upgrade | avg > 58 FPS | 8 s |
| Cooldown after any change | — | 5 s |

Upgrades get the longer window on purpose: briefly too conservative costs sparkle, briefly too ambitious costs frames mid-run — the thing players actually feel in a reaction-time game. The boot verdict is the ceiling, so adaptation recovers ground it gave up but never promotes a device past what it measured. Frames > 0.25 s (tab-switch, GC) are discarded, not counted, so one hitch can't drop everyone's quality. Telemetry suspends outside gameplay so an idle menu isn't read as headroom.

A downgrade tears down post-processing; an upgrade does **not** rebuild it — recompiling shaders would stall exactly the frames the upgrade was meant to reward.

**Player override.** `setPreference()` / `getPreference()` pin a tier and disable adaptation, persisted under `toiletRunner_quality`. Deliberately a separate key from the unified stats blob: a tier must be picked before `StatsManager` has loaded, so sharing the key would be an ordering hazard. No UI surfaces this yet.

## Testing

`AdaptiveQuality` was designed pure and WebGL-free (integer tier indices, time accumulated from fed deltas) specifically so the state machine is deterministic under test. 10 new tests cover: boot cooldown, single-tier drop, full-window requirement, cooldown between changes, ceiling clamp, floor clamp, outlier-delta rejection, and `reset()`.

- `bun run typecheck` clean
- `bun test` — 94 pass / 0 fail (was 84)

Closes #80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)