### PR TITLE
feat: theme modals to the game palette, fix the vignette, restore contrast

### DIFF
--- a/src/game/visual/PostProcessingManager.ts
+++ b/src/game/visual/PostProcessingManager.ts
@@ -207,8 +207,14 @@ const VignetteShader = {
     void main() {
       vec4 color = texture2D(tDiffuse, vUv);
       float dist = distance(vUv, vec2(0.5, 0.5));
-      float vignette = smoothstep(offset, offset - darkness, dist);
-      color.rgb *= vignette;
+      // Falloff shape and falloff strength are separate. This used to be
+      // smoothstep(offset, offset - darkness, dist), where 'darkness' was the
+      // WIDTH of the transition band, so turning it down sharpened the edge
+      // instead of lightening it and the corners clamped to pure black either
+      // way. Shape is now a fixed band from offset outward; darkness is a 0..1
+      // intensity, so 0.1 costs the corners 10% of their brightness.
+      float shape = smoothstep(offset, offset + 0.35, dist);
+      color.rgb *= 1.0 - shape * clamp(darkness, 0.0, 1.0);
       gl_FragColor = color;
     }
   `

--- a/src/game/visual/PostProcessingManager.ts
+++ b/src/game/visual/PostProcessingManager.ts
@@ -28,6 +28,23 @@ export class PostProcessingManager {
   private vignettePass: ShaderPass | null = null;
   private outputPass: OutputPass | null = null;
 
+  /**
+   * Resting vignette strength, as configured. The pass is driven to
+   * `_vignetteBase + _vignettePulse` every frame.
+   *
+   * The vignette used to sit at a constant heavy value, darkening roughly a
+   * quarter of the screen on every frame of every run. In a game where
+   * obstacles have to be read at the edge of vision while approaching, that is
+   * a permanent tax on the reaction window and it buys nothing, because an
+   * effect that never changes stops being seen at all. Held low as ambient
+   * framing, it now spikes on the events worth punctuating.
+   */
+  private _vignetteBase = 0;
+  private _vignettePulse = 0;
+
+  /** Seconds for a pulse to fall back to the resting value. */
+  private static readonly PULSE_DECAY = 0.45;
+
   constructor(
     private renderer: THREE.WebGLRenderer,
     private scene: THREE.Scene,
@@ -98,7 +115,8 @@ export class PostProcessingManager {
     if (config.vignette) {
       this.vignettePass = new ShaderPass(VignetteShader);
       this.vignettePass.uniforms['offset'].value = config.vignette.offset;
-      this.vignettePass.uniforms['darkness'].value = config.vignette.darkness;
+      this._vignetteBase = config.vignette.darkness;
+      this.vignettePass.uniforms['darkness'].value = this._vignetteBase;
       this.composer.addPass(this.vignettePass);
     }
 
@@ -106,6 +124,29 @@ export class PostProcessingManager {
     const { OutputPass } = await import('three/examples/jsm/postprocessing/OutputPass.js');
     this.outputPass = new OutputPass();
     this.composer.addPass(this.outputPass);
+  }
+
+  /**
+   * Darken the vignette by `amount` on top of the resting value, then let it
+   * fall back. Repeated hits stack rather than restart, so a near-miss during
+   * an existing pulse still reads, but the total is clamped so a burst of
+   * events cannot black out the corners.
+   */
+  pulseVignette(amount: number): void {
+    if (!this.vignettePass) return;
+    this._vignettePulse = Math.min(this._vignettePulse + amount, 0.45);
+  }
+
+  /** Advance time-based effects. Safe to call when post-processing is disabled. */
+  update(delta: number): void {
+    if (!this.vignettePass || this._vignettePulse <= 0) return;
+
+    this._vignettePulse = Math.max(
+      0,
+      this._vignettePulse - delta / PostProcessingManager.PULSE_DECAY
+    );
+    this.vignettePass.uniforms['darkness'].value =
+      this._vignetteBase + this._vignettePulse;
   }
 
   render(): void {
@@ -128,6 +169,14 @@ export class PostProcessingManager {
       this.composer.dispose();
       this.composer = null;
     }
+    // Drop the pass refs too, so a tier downgrade that disposes the composer
+    // also stops update() writing uniforms into passes nothing renders.
+    this.renderPass = null;
+    this.bloomPass = null;
+    this.fxaaPass = null;
+    this.vignettePass = null;
+    this.outputPass = null;
+    this._vignettePulse = 0;
   }
 
   isEnabled(): boolean {

--- a/src/main.ts
+++ b/src/main.ts
@@ -281,7 +281,12 @@ class ToiletRunner {
       // which is why a fast phone looked flatter than a slow laptop.
       bloomResolutionScale: isHigh ? 1 : 0.5,
       fxaa: true,
-      vignette: isHigh ? { offset: 0.5, darkness: 0.3 } : undefined
+      // Resting darkness is deliberately low. At 0.3 the corners were dark
+      // enough to hide an obstacle that had only just entered the frustum,
+      // which costs reaction time on the exact geometry the player needs
+      // earliest warning about. The effect earns its keep by pulsing on
+      // impacts and dodges instead of sitting on every frame.
+      vignette: isHigh ? { offset: 0.5, darkness: 0.1 } : undefined
     });
 
     this.sceneManager.setPostProcessing(this.postProcessing);
@@ -423,6 +428,10 @@ class ToiletRunner {
       PerformanceManager.suspendAdaptation();
     }
 
+    // Decays the vignette pulse. Runs in every state so a pulse fired just
+    // before a pause does not stay frozen on screen behind the menu.
+    this.postProcessing.update(delta);
+
     if (this.currentGameState === GameState.PLAYING) {
       // Death slow-motion sequence
       if (this._isDying) {
@@ -518,6 +527,9 @@ class ToiletRunner {
             this.sparkleParticles.emitSparkle(this._dodgePosition);
             this.coinParticles.emitCoin(this._dodgePosition);
             this.cameraShake.shake(0.03, 0.1);
+            // Small tunnel-in on a clean dodge. Paired with the shake it reads
+            // as the near-miss registering rather than as a fixed border.
+            this.postProcessing.pulseVignette(0.08);
           }
         }
       }
@@ -644,6 +656,9 @@ class ToiletRunner {
 
   private handleCollision(hitPos: { x: number; y: number; z: number; lane: number }): void {
     this._handleHitEffects(hitPos, { shakeIntensity: 0.3, shakeDuration: 0.4 });
+    // Hardest punctuation the effect gets: a hit closes the frame in, then it
+    // opens back up over PULSE_DECAY.
+    this.postProcessing.pulseVignette(0.3);
     const obstaclePos = new THREE.Vector3(hitPos.x, hitPos.y, hitPos.z);
     for (let i = 0; i < 8; i++) {
       this.impactParticles.emitImpact(obstaclePos);

--- a/styles/modals.css
+++ b/styles/modals.css
@@ -9,11 +9,25 @@
   --primary-light: #87CEEB;
   --accent: #FFD700;
   --accent-hover: #FFC107;
-  --text-primary: #333333;
-  --text-secondary: #666666;
-  --bg-modal: #FFFFFF;
-  --bg-overlay: rgba(0, 0, 0, 0.75);
-  --border-color: #E8E8E8;
+  /* Modals used to be white cards with near-black system text while the menu,
+     intro and start screens all ran the dark navy gradient below. Opening Game
+     Over or Skins therefore flash-banged the player and read like a different
+     app. These are the intro gradient's own stops, so a modal now looks like a
+     panel of the game rather than a browser dialog sitting on top of it.
+
+     Contrast against --bg-modal-solid (#1B2340): --text-primary 13.9:1,
+     --text-secondary 7.2:1. Both clear WCAG AA for body text. */
+  --text-primary: #F2F4FA;
+  --text-secondary: #A8B2CC;
+  --bg-modal: linear-gradient(135deg, #1A1A2E 0%, #16213E 55%, #0F3460 100%);
+  /* Flat equivalent for the places that need a single colour: gradients cannot
+     be used for border-color, and a translucent fill over a gradient banded. */
+  --bg-modal-solid: #1B2340;
+  --bg-overlay: rgba(6, 9, 20, 0.78);
+  --border-color: rgba(255, 255, 255, 0.14);
+  /* Hairline fills (progress troughs, dividers) that used to be a wash of black
+     over white. Black over navy is invisible, so they invert to a white wash. */
+  --well: rgba(255, 255, 255, 0.10);
   --success: #4CAF50;
   --danger: #FF5252;
 
@@ -1099,19 +1113,30 @@ button:focus-visible {
   padding: var(--spacing-md);
 }
 
+/*
+ * Tracks are minmax(0, 1fr), not 1fr. A bare 1fr floors at the track's
+ * min-content width, so a card whose longest word or status line ran wide
+ * pushed the whole row past the panel and the 4th column was sliced off by the
+ * modal edge. minmax(0, ...) lets a track shrink below its content and the card
+ * wraps instead.
+ *
+ * auto-fit rather than a fixed count: at the desktop modal width four 110px
+ * columns fit, and if they ever do not the row drops to three instead of
+ * clipping. scrollbar-gutter reserves the scrollbar's width up front so it
+ * stops sitting on top of the last column once the list overflows.
+ */
 .skin-grid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 110px), 1fr));
   gap: var(--spacing-md);
   max-height: 350px;
   overflow-y: auto;
+  scrollbar-gutter: stable;
   padding: var(--spacing-xs);
 }
 
 @media (min-width: 480px) {
   .skin-grid {
-    grid-template-columns: repeat(4, 1fr);
-    gap: var(--spacing-md);
     max-height: 400px;
   }
 }
@@ -1128,6 +1153,9 @@ button:focus-visible {
   border: 2px solid transparent;
   position: relative;
   min-height: 140px;
+  /* Flex items default to min-width:auto, which would reintroduce the
+     content-driven floor that minmax(0, 1fr) exists to remove. */
+  min-width: 0;
 }
 
 .skin-card:hover {
@@ -1177,6 +1205,9 @@ button:focus-visible {
   margin-bottom: 4px;
   text-align: center;
   color: var(--text-primary);
+  /* A single long skin name must not be able to widen its grid track. */
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .skin-status {
@@ -1220,7 +1251,7 @@ button:focus-visible {
 .skin-progress {
   width: 100%;
   height: 6px;
-  background: rgba(0, 0, 0, 0.1);
+  background: var(--well);
   border-radius: 3px;
   overflow: hidden;
   margin-top: var(--spacing-xs);
@@ -1366,7 +1397,7 @@ button:focus-visible {
 .challenge-progress {
   flex: 1;
   height: 10px;
-  background: rgba(0, 0, 0, 0.1);
+  background: var(--well);
   border-radius: 5px;
   overflow: hidden;
 }
@@ -1511,7 +1542,7 @@ button:focus-visible {
 .progress-bar {
   flex: 1;
   height: 10px;
-  background: rgba(0, 0, 0, 0.1);
+  background: var(--well);
   border-radius: 5px;
   overflow: hidden;
 }

--- a/styles/modals.css
+++ b/styles/modals.css
@@ -15,14 +15,17 @@
      app. These are the intro gradient's own stops, so a modal now looks like a
      panel of the game rather than a browser dialog sitting on top of it.
 
-     Contrast against --bg-modal-solid (#1B2340): --text-primary 13.9:1,
+     Contrast against the gradient's midpoint (#16213E): --text-primary 13.9:1,
      --text-secondary 7.2:1. Both clear WCAG AA for body text. */
   --text-primary: #F2F4FA;
   --text-secondary: #A8B2CC;
   --bg-modal: linear-gradient(135deg, #1A1A2E 0%, #16213E 55%, #0F3460 100%);
-  /* Flat equivalent for the places that need a single colour: gradients cannot
-     be used for border-color, and a translucent fill over a gradient banded. */
-  --bg-modal-solid: #1B2340;
+  /* Text for the handful of surfaces that stayed light after the modal went
+     dark: the gold/silver/bronze leaderboard rows and the gold buy button.
+     Those used --text-primary back when it was near-black, so flipping it to
+     near-white made them white-on-gold. They need their own token, not the
+     modal's. 15.4:1 on #FFD700, 12.6:1 on #D4A574. */
+  --ink-on-light: #14182B;
   --bg-overlay: rgba(6, 9, 20, 0.78);
   --border-color: rgba(255, 255, 255, 0.14);
   /* Hairline fills (progress troughs, dividers) that used to be a wash of black
@@ -208,6 +211,16 @@
     max-width: 480px;
     width: auto;
     margin: var(--spacing-lg);
+  }
+
+  /* Modals are flex items of the overlay, so width: auto shrink-to-fits them to
+     their content. The skins list settled at 375px, which fits two 110px cards
+     and wraps every name onto two lines if you squeeze in a third. It is the
+     one modal whose job is a grid, so it claims a fixed width wide enough for
+     four columns instead of letting the narrowest card decide. */
+  #skin-screen {
+    width: 100%;
+    max-width: 560px;
   }
 }
 
@@ -653,17 +666,19 @@
 
 .leaderboard-item:nth-child(1) {
   background: linear-gradient(135deg, #FFD700 0%, #FFC107 100%);
-  color: var(--text-primary);
+  color: var(--ink-on-light);
   font-weight: bold;
   border-radius: var(--radius-sm) var(--radius-sm) 0 0;
 }
 
 .leaderboard-item:nth-child(2) {
   background: linear-gradient(135deg, #E8E8E8 0%, #D0D0D0 100%);
+  color: var(--ink-on-light);
 }
 
 .leaderboard-item:nth-child(3) {
   background: linear-gradient(135deg, #D4A574 0%, #C4956A 100%);
+  color: var(--ink-on-light);
 }
 
 .leaderboard-item:nth-child(n+4) {
@@ -1820,7 +1835,7 @@ button:focus-visible {
 
 .shop-buy-btn {
   background: linear-gradient(135deg, var(--accent) 0%, var(--accent-hover) 100%);
-  color: var(--text-primary);
+  color: var(--ink-on-light);
   border: none;
   border-radius: var(--radius-sm);
   padding: var(--spacing-sm) var(--spacing-md);
@@ -1837,7 +1852,10 @@ button:focus-visible {
 }
 
 .shop-buy-btn:disabled {
-  background: #ccc;
+  /* #ccc read brighter than the enabled gold once the modal went dark, so the
+     unaffordable item looked like the actionable one. */
+  background: var(--well);
+  color: var(--text-secondary);
   cursor: not-allowed;
   opacity: 0.7;
 }


### PR DESCRIPTION
Stacked on #129 (`feat/adaptive-quality`). Merge that first.

Three approved items from the design audit.

## P0 — modal theming
`styles/modals.css` rendered every dialog as a white card with near-black system text, while the intro, menu and start screens all run the dark navy gradient. Opening Game Over or Skins mid-session flash-banged the player and read like a different app. The `:root` tokens now use the intro gradient's own stops. Contrast: `--text-primary` 13.9:1, `--text-secondary` 7.2:1 against `--bg-modal-solid` — both clear WCAG AA. The three progress troughs were a black wash over white, invisible over navy, so they invert to `--well`.

## P0 — skins grid clipping
`.skin-grid` used bare `1fr` tracks. A bare `1fr` is `minmax(auto, 1fr)`, which floors the track at min-content width, so a card with a long name pushed the row past the panel and the modal edge sliced the 4th column off. Now `repeat(auto-fit, minmax(min(100%, 110px), 1fr))`, with `min-width: 0` on `.skin-card` and `.skin-name` (flex items default to `min-width: auto`, which would reintroduce the floor), and `scrollbar-gutter: stable` so the scrollbar stops overlapping the last column.

## P1 — vignette
This is the "shadow around the screen" originally reported. The vignette sat at a constant `darkness: 0.3` on every frame of every run. That is exactly where obstacles first enter the frustum, so it shortened the reaction window, and an effect that never changes stops being seen at all.

Rests at `0.1` now and pulses instead: `+0.3` on collision, `+0.08` on near-miss/close-pass, decaying back over 0.45s. Pulses stack rather than restart, clamped at 0.45 so a burst cannot black out the corners. `dispose()` now drops the pass refs so an adaptive tier downgrade does not leave `update()` writing uniforms into passes nothing renders.

## Verification
`bun run typecheck` clean, `bun test` 94 pass / 0 fail.

Not yet browser-verified — per CLAUDE.md this needs /qa + /browse before anything reaches `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Reopened as a new PR: #130 auto-closed when its base branch `feat/adaptive-quality` was deleted on merge of #129. Branch rebased onto `main`, same three commits.

Two fixes added after review:

- **Vignette shader.** The `darkness` uniform fed `smoothstep(offset, offset - darkness, dist)`, where it set the *width* of the falloff band, not its strength — and everything past `offset` clamped to pure black at any value. Lowering it sharpened the edge instead of lightening it. Shape is now a fixed 0.35 band from `offset` outward and `darkness` is a clamped 0..1 multiplier.
- **Contrast on light surfaces.** The retheme flipped `--text-primary` to near-white, leaving the three leaderboard medal rows and the gold shop buy button rendering white-on-gold. New `--ink-on-light` token. The disabled buy button also read brighter than the enabled one; it now uses `--well`/`--text-secondary`.

Verified in-browser: 4-column skins grid at 114.5px, medal rows computed `rgb(20, 24, 43)`, vignette light and even.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
