### PR TITLE
chore: bump version to 1.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toilet-runner",
-  "version": "1.12.1",
+  "version": "1.13.0",
   "description": "3D endless runner with toilet paper roll avoiding poop obstacles",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Release v1.13.0.

Includes measured performance tiering + adaptive quality (#129) and modal retheme + vignette fix (#131).

Verified: typecheck, 94 unit tests, build all pass; production /qa + /browse pass (run loop, pause/resume, game over, leaderboard, all modals, no console errors, vignette frame gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)