### PR TITLE
docs: document coins, correct the obstacle instancing claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ A humorous 3D endless runner where a toilet paper roll runs forward, avoiding pi
 - **Obstacles:** pooled piles of poop (jump or dodge) plus `BARRIER_HIGH` walls that are taller
   than the jump apex, so they can only be dodged by changing lane. See
   [Obstacle types](docs/architecture.html) for hitbox dimensions.
+- **Coins:** gold pickups spawn between the obstacles, one `InstancedMesh` for the whole pool.
+  The shop's coin magnet widens the pickup radius. Coins are also awarded for near-misses and
+  close passes.
 - **Performance:** Target 55-60 FPS on mobile devices
 
 ## Architecture
@@ -70,7 +73,9 @@ A humorous 3D endless runner where a toilet paper roll runs forward, avoiding pi
 ### Game Systems
 - **RunnerController:** Lane-based movement with smooth lerp interpolation
 - **TrackManager:** Endless segments spawning/despawning
-- **ObstacleManager:** InstancedMesh obstacles with spawn patterns
+- **ObstacleManager:** pooled `THREE.Group` obstacles with spawn patterns (not instanced — each
+  is 4-6 meshes)
+- **CoinManager:** pooled collectible coins, one `InstancedMesh`, live prefix only
 - **CollisionSystem:** AABB collision using THREE.Box3
 
 ### Input & UI
@@ -81,12 +86,14 @@ A humorous 3D endless runner where a toilet paper roll runs forward, avoiding pi
 
 - **Measured quality tier:** A GPU-synced boot benchmark grades the device and picks LOW/MEDIUM/HIGH. No user-agent sniffing — a fast phone gets the same effects a fast laptop does.
 - **Adaptive quality:** `AdaptiveQuality` watches delivered frame times during play and drops a tier after 3s below 45 FPS, climbing back after 8s above 58 FPS (5s cooldown between changes). Thermal throttling and background tabs get corrected mid-run.
-- **InstancedMesh:** 1 draw call for 50+ obstacles
+- **InstancedMesh:** track segments, lane lines, and coins each render in 1 draw call. Obstacles
+  are *not* instanced — they are groups of 4-6 meshes, so real obstacle draw calls scale with the
+  number on screen. Converting them is open work.
 - **Pixel ratio:** Clamped to 2x, tier-selected
 - **Object pooling:** Reduce GC pressure
 - **Fog:** Hide distant geometry
 - **Simple materials:** MeshLambertMaterial (not PBR)
-- **Draw calls:** <10 total
+- **Draw calls:** <10 total (aspirational — obstacles blow past this today)
 - **Triangles:** <10,000
 
 ## CI / CD

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -53,7 +53,8 @@ graph TD
   subgraph Game["src/game — gameplay"]
     RC[RunnerController<br/>3 lanes, lerp]
     TM[TrackManager<br/>InstancedMesh segments]
-    OM[ObstacleManager<br/>pooled InstancedMesh]
+    OM[ObstacleManager<br/>pooled THREE.Group]
+    COIN[CoinManager<br/>pooled InstancedMesh]
     CS[CollisionSystem<br/>AABB / Box3]
     DM[DifficultyManager]
     PS[PatternSequencer]
@@ -90,6 +91,8 @@ graph TD
   M --> SCR --> UIM
   M --> HUD
   M --> SV --> UIM
+  OM --> COIN
+  COIN --> SH
   OM --> PART
   OM --> ETA & MF
   M --> SL
@@ -247,7 +250,7 @@ for headroom. A downgrade tears down post-processing; an upgrade does not rebuil
 recompiling shaders would stall exactly the frames the upgrade was meant to reward.
 </p>
 <ul>
-  <li><strong>InstancedMesh</strong> for track segments and obstacles — target &lt;10 draw calls, &lt;10K triangles.</li>
+  <li><strong>InstancedMesh</strong> for track segments, lane lines, and coins. Obstacles are pooled <code>THREE.Group</code>s of 4-6 meshes, not instanced, so the &lt;10 draw call target is aspirational.</li>
   <li><strong>Object pooling</strong> for obstacles; no per-frame allocations in hot loops. Reuse
       <code>THREE.Vector3</code>/<code>Box3</code> instances in <code>update()</code>.</li>
   <li><strong>MeshLambertMaterial</strong> everywhere, no PBR.</li>
@@ -330,7 +333,7 @@ Vite is configured with <code>base: './'</code> — required for GitHub Pages as
 </table>
 
 <footer>
-  Last updated 2026-08-11 · <a href="../README.md">README</a> ·
+  Last updated 2026-08-12 · <a href="../README.md">README</a> ·
   <a href="https://bigknoxy.github.io/toilet-runner/">Play</a>
 </footer>
 


### PR DESCRIPTION
Doc sync for #134 plus a long-standing false claim.

- README `## Game Concept` and `### Game Systems` now mention `CoinManager`.
- README and `docs/architecture.html` both said `ObstacleManager` uses `InstancedMesh` at "1 draw call for 50+ obstacles". `createObstacleGroup` builds a `THREE.Group` of 4-6 individual meshes, so that was never true. Corrected, with the `<10` draw-call target labelled aspirational.
- Architecture topology graph gains a `COIN` node (`CM` was already `CameraManager`).
- Footer timestamp bumped to 2026-08-12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)