### PR TITLE
fix: raise obstacle contrast against fog at spawn distance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toilet-runner",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "3D endless runner with toilet paper roll avoiding poop obstacles",
   "type": "module",
   "scripts": {

--- a/src/game/ObstacleManager.ts
+++ b/src/game/ObstacleManager.ts
@@ -22,6 +22,19 @@ const BARRIER_HALF_WIDTH = 1.2;
 const BARRIER_HALF_DEPTH = 0.35;
 const POOP_CENTER_Y = 0.3;
 
+// Emissive terms are added to the lit color before the fog mix runs, so they
+// widen the obstacle's contrast against the horizon for the whole approach
+// instead of just fighting fog at close range (fog still wins at the spawn
+// plane, which is the point — distant pop-in should stay hidden). BARRIER_HIGH
+// gets the strongest glow of the three: it is the one obstacle type the player
+// cannot recover from by jumping, so it needs to read as "different" before a
+// poop pile would, not just brighter.
+const POOP_EMISSIVE = 0x3D2210;
+const POOP_EMISSIVE_INTENSITY = 0.45;
+const BARRIER_EMISSIVE = 0x8C1F12;
+const BARRIER_EMISSIVE_INTENSITY = 0.55;
+const BARRIER_STRIPE_EMISSIVE_INTENSITY = 0.35;
+
 export interface ActiveObstacle {
   x: number;
   y: number;
@@ -100,7 +113,11 @@ export class ObstacleManager {
     }
 
     // Materials
-    this._bodyMaterial = new THREE.MeshLambertMaterial({ color: 0x8B5E3C });
+    this._bodyMaterial = new THREE.MeshLambertMaterial({
+      color: 0x8B5E3C,
+      emissive: POOP_EMISSIVE,
+      emissiveIntensity: POOP_EMISSIVE_INTENSITY
+    });
     this._bodyMaterial.side = THREE.FrontSide;
     this._eyeMaterial = new THREE.MeshBasicMaterial({ color: 0xFFFFFF });
     this._eyeMaterial.side = THREE.FrontSide;
@@ -121,13 +138,21 @@ export class ObstacleManager {
       BARRIER_HALF_HEIGHT * 2,
       BARRIER_HALF_DEPTH * 2
     );
-    this._barrierMaterial = new THREE.MeshLambertMaterial({ color: 0xC23B22 });
+    this._barrierMaterial = new THREE.MeshLambertMaterial({
+      color: 0xC23B22,
+      emissive: BARRIER_EMISSIVE,
+      emissiveIntensity: BARRIER_EMISSIVE_INTENSITY
+    });
     this._barrierStripeGeometry = new THREE.BoxGeometry(
       BARRIER_HALF_WIDTH * 2.05,
       0.3,
       BARRIER_HALF_DEPTH * 2.05
     );
-    this._barrierStripeMaterial = new THREE.MeshLambertMaterial({ color: 0xF2E8C9 });
+    this._barrierStripeMaterial = new THREE.MeshLambertMaterial({
+      color: 0xF2E8C9,
+      emissive: 0xF2E8C9,
+      emissiveIntensity: BARRIER_STRIPE_EMISSIVE_INTENSITY
+    });
 
     // Initialize pool
     this.initializeObstaclePool();


### PR DESCRIPTION
## Problem

Obstacles fade into the horizon haze at exactly the distance where the player needs to identify them and commit to a lane. By the time they read clearly, the reaction window is mostly gone. Brown poop piles against a light fog plane are the worst case. `BARRIER_HIGH` shares the problem and matters more, since it cannot be jumped — the correct input differs from a poop pile, but at distance they look alike.

## Fix

Adds an emissive term to the three obstacle materials built in the `ObstacleManager` constructor:

| material | before | after |
|---|---|---|
| `_bodyMaterial` (poop) | `{ color: 0x8B5E3C }` | `+ emissive 0x3D2210 @ 0.45` |
| `_barrierMaterial` (BARRIER_HIGH) | `{ color: 0xC23B22 }` | `+ emissive 0x8C1F12 @ 0.55` |
| `_barrierStripeMaterial` (hazard stripe) | `{ color: 0xF2E8C9 }` | `+ self-emissive @ 0.35` |

Emissive is summed into the lit fragment color before the fog mix, so the obstacle holds its own color further out without changing where fog wins near the spawn plane — distant pop-in stays hidden. `BARRIER_HIGH` gets the strongest glow so the un-jumpable obstacle separates from a jumpable pile earlier, reinforcing the existing hazard stripe rather than duplicating it.

Fog near/far in `SceneManager` was left alone: it carries prior reaction-window tuning from #71/#74 and re-tuning it would fight a trade-off that was already reasoned through.

## Performance

Materials are shared across the whole pool, so this is a one-time constructor change. No new draw calls, no new materials per obstacle, no per-frame allocations, no new render passes. Still `MeshLambertMaterial` throughout.

## Version

Bumps `package.json` to `1.14.0`. `v1.14.0` gets tagged after this merges — the last tag is `v1.8.0`, so coins, near-miss rewards, and name entry are all currently untagged.

## Verification

- `bun run typecheck` clean
- `bun test` — 99 pass / 0 fail / 440 expect() / 13 files
- `bun run build` OK

No test added: this is static material tuning in a constructor, not an execution-order or state-lifetime change, so a test would only restate the constants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)